### PR TITLE
Add subtree export option and improve endpoint handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ opcua-nodeset-export [options]
 
 Options:
   -e, --endpoint <endpoint>           OPC UA server endpoint URL (e.g., opc.tcp://localhost:4840)
+  -s, --start-node <node>             Export subtree from this ExpandedNodeId (e.g., nsu=example.com/opcua/;i=5)
   -m, --security-mode <mode>          Security mode: None, Sign, SignAndEncrypt [default: None]
   -p, --security-policy <policy>      Security policy: None, Basic256Sha256, Aes128_Sha256_RsaOaep, Aes256_Sha256_RsaPss [default: None]
   -a, --auth-mode <mode>              Authentication mode: Anonymous, UserName, Certificate [default: Anonymous]
@@ -71,6 +72,7 @@ The following environment variables can be used to configure the tool:
 | Variable | Description | CLI Equivalent |
 |----------|-------------|----------------|
 | `OPCUA_ENDPOINT` | OPC UA server endpoint URL | `--endpoint` |
+| `OPCUA_START_NODE` | ExpandedNodeId for subtree export | `--start-node` |
 | `OPCUA_USERNAME` | Username for authentication | `--username` |
 | `OPCUA_PASSWORD` | Password for authentication | `--password` |
 | `OPCUA_CERTIFICATE_PATH` | Path to client certificate | `--certificate-path` |
@@ -87,6 +89,26 @@ opcua-nodeset-export -e opc.tcp://localhost:4840
 # Export to custom directory
 opcua-nodeset-export -e opc.tcp://localhost:4840 -o ./my-nodesets
 ```
+
+### Subtree Export
+
+Export a specific subtree starting from a given node. Only type definitions in the same namespace as the start node are included; types from other namespaces are referenced but not exported.
+
+```bash
+# Export subtree starting from a specific node (ExpandedNodeId format)
+opcua-nodeset-export -e opc.tcp://localhost:4840 -s "ns=4;i=5"
+
+# Export subtree with custom output directory
+opcua-nodeset-export -e opc.tcp://localhost:4840 -s "ns=4;i=5" -o ./subtree-export
+
+# Export subtree using a string node ID
+opcua-nodeset-export -e opc.tcp://localhost:4840 -s "ns=3;s=MyDevice"
+```
+
+The output is a single NodeSet2 XML file containing:
+- The start node and all its subnodes (via hierarchical references)
+- Type definitions used by the subtree that are in the same namespace as the start node
+- Supertypes of included types (if also in the same namespace)
 
 ### Secure Connection
 

--- a/src/OpcUaNodesetExporter/Commands/ExportCommand.cs
+++ b/src/OpcUaNodesetExporter/Commands/ExportCommand.cs
@@ -129,6 +129,14 @@ public class ExportCommand : RootCommand
             DefaultValueFactory = (_) => false
         };
 
+        var startNodeOption = new Option<string?>(
+            name: "--start-node",
+            aliases: new[] { "-s" })
+        {
+            Description = "Export a subtree starting from this ExpandedNodeId (e.g., ns=4;i=5). Only includes type definitions in the same namespace.",
+            DefaultValueFactory = (_) => EnvironmentVariables.GetValue(EnvironmentVariables.StartNode)
+        };
+
         // Add all options
         Options.Add(endpointOption);
         Options.Add(securityModeOption);
@@ -144,6 +152,7 @@ public class ExportCommand : RootCommand
         Options.Add(retryCountOption);
         Options.Add(retryDelayOption);
         Options.Add(verboseOption);
+        Options.Add(startNodeOption);
 
         this.SetAction(async (parseResult, cancellationToken) =>
         {
@@ -161,6 +170,7 @@ public class ExportCommand : RootCommand
             var retryCount = parseResult.GetValue(retryCountOption);
             var retryDelay = parseResult.GetValue(retryDelayOption);
             var verbose = parseResult.GetValue(verboseOption);
+            var startNode = parseResult.GetValue(startNodeOption);
 
             return await ExecuteAsync(
                 endpoint,
@@ -177,6 +187,7 @@ public class ExportCommand : RootCommand
                 retryCount,
                 retryDelay,
                 verbose,
+                startNode,
                 cancellationToken);
         });
     }
@@ -196,6 +207,7 @@ public class ExportCommand : RootCommand
         int retryCount,
         int retryDelay,
         bool verbose,
+        string? startNode,
         CancellationToken cancellationToken)
     {
         // Configure logging
@@ -310,21 +322,45 @@ public class ExportCommand : RootCommand
                 client,
                 options.Verbose);
 
-            var exportedFiles = await exporter.ExportAllNamespacesAsync(
-                options.OutputDirectory,
-                cancellationToken);
-
-            // Print summary
-            logger.LogInformation("");
-            logger.LogInformation("Export Summary");
-            logger.LogInformation("==============");
-            foreach (var kvp in exportedFiles)
+            if (!string.IsNullOrEmpty(startNode))
             {
-                logger.LogInformation("  {Namespace} -> {File}", kvp.Key, Path.GetFileName(kvp.Value));
+                // Subtree export mode
+                var startNodeId = ExpandedNodeId.Parse(startNode, client.Session.NamespaceUris);
+                logger.LogInformation("Exporting subtree from {StartNode}...", startNodeId);
+
+                var exportedFile = await exporter.ExportSubtreeAsync(
+                    startNodeId,
+                    options.OutputDirectory,
+                    cancellationToken);
+
+                logger.LogInformation("");
+                logger.LogInformation("Export Summary");
+                logger.LogInformation("==============");
+                logger.LogInformation("  Subtree root: {StartNode}", startNodeId);
+                logger.LogInformation("  Output: {File}", Path.GetFileName(exportedFile));
+                logger.LogInformation("");
+                logger.LogInformation("Successfully exported subtree to {File}",
+                    Path.GetFullPath(exportedFile));
             }
-            logger.LogInformation("");
-            logger.LogInformation("Successfully exported {Count} namespace(s) to {Directory}",
-                exportedFiles.Count, Path.GetFullPath(options.OutputDirectory));
+            else
+            {
+                // Full namespace export mode
+                var exportedFiles = await exporter.ExportAllNamespacesAsync(
+                    options.OutputDirectory,
+                    cancellationToken);
+
+                // Print summary
+                logger.LogInformation("");
+                logger.LogInformation("Export Summary");
+                logger.LogInformation("==============");
+                foreach (var kvp in exportedFiles)
+                {
+                    logger.LogInformation("  {Namespace} -> {File}", kvp.Key, Path.GetFileName(kvp.Value));
+                }
+                logger.LogInformation("");
+                logger.LogInformation("Successfully exported {Count} namespace(s) to {Directory}",
+                    exportedFiles.Count, Path.GetFullPath(options.OutputDirectory));
+            }
 
             return 0;
         }

--- a/src/OpcUaNodesetExporter/Configuration/EnvironmentVariables.cs
+++ b/src/OpcUaNodesetExporter/Configuration/EnvironmentVariables.cs
@@ -31,6 +31,11 @@ public static class EnvironmentVariables
     public const string CertificatePassword = "OPCUA_CERTIFICATE_PASSWORD";
 
     /// <summary>
+    /// Environment variable for the start node ExpandedNodeId (subtree export).
+    /// </summary>
+    public const string StartNode = "OPCUA_START_NODE";
+
+    /// <summary>
     /// Gets the value of an environment variable, returning null if not set or empty.
     /// </summary>
     /// <param name="variableName">The name of the environment variable.</param>

--- a/src/OpcUaNodesetExporter/OpcUa/NodeSetExporter.cs
+++ b/src/OpcUaNodesetExporter/OpcUa/NodeSetExporter.cs
@@ -74,6 +74,279 @@ public class NodeSetExporter
     }
 
     /// <summary>
+    /// Exports a subtree starting from a specific node to a single NodeSet2 XML file.
+    /// Includes the start node, all its subnodes (via hierarchical references), and
+    /// type definitions that are in the same namespace as the start node and used by the subtree.
+    /// </summary>
+    /// <param name="startNodeId">The ExpandedNodeId of the root node for the subtree export.</param>
+    /// <param name="outputDirectory">Directory to save the NodeSet2 file.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The path to the exported NodeSet2 XML file.</returns>
+    public async Task<string> ExportSubtreeAsync(
+        ExpandedNodeId startNodeId,
+        string outputDirectory,
+        CancellationToken cancellationToken = default)
+    {
+        _logger.LogInformation("Starting subtree export from {StartNode} to {OutputDirectory}",
+            startNodeId, outputDirectory);
+        var stopwatch = Stopwatch.StartNew();
+
+        Directory.CreateDirectory(outputDirectory);
+
+        _logger.LogInformation("Loading type system...");
+        await LoadTypeSystemAsync(cancellationToken).ConfigureAwait(false);
+
+        _logger.LogInformation("Fetching subtree nodes from {StartNode}...", startNodeId);
+        var subtreeNodes = await FetchSubtreeNodesAsync(startNodeId, cancellationToken).ConfigureAwait(false);
+        _logger.LogInformation("Fetched {Count} subtree nodes.", subtreeNodes.Count);
+
+        var startNamespaceIndex = startNodeId.NamespaceIndex;
+        _logger.LogInformation("Collecting type definitions in namespace index {Namespace}...", startNamespaceIndex);
+        var typeDefinitions = await CollectUsedTypeDefinitionsAsync(
+            subtreeNodes, startNamespaceIndex, cancellationToken).ConfigureAwait(false);
+        _logger.LogInformation("Collected {Count} type definitions.", typeDefinitions.Count);
+
+        // Combine instance nodes and type definitions, avoiding duplicates
+        var allNodes = new Dictionary<ExpandedNodeId, INode>();
+        foreach (var node in subtreeNodes)
+        {
+            allNodes[node.NodeId] = node;
+        }
+        foreach (var node in typeDefinitions)
+        {
+            allNodes[node.NodeId] = node;
+        }
+
+        var combinedNodes = allNodes.Values.ToList();
+        combinedNodes.Sort((x, y) => x.NodeId.CompareTo(y.NodeId));
+
+        // Generate output file name from the start node
+        var session = _client.Session;
+        string namespaceUri = session.NamespaceUris.GetString(startNamespaceIndex);
+        string fileName = CreateSafeFileName(namespaceUri, startNamespaceIndex);
+        string filePath = Path.Combine(outputDirectory, fileName);
+
+        _logger.LogInformation("Exporting {Count} nodes to {File}...", combinedNodes.Count, fileName);
+
+        await Task.Run(() =>
+        {
+            ExportNodesToNodeSet2File(session, combinedNodes, filePath);
+        }, cancellationToken).ConfigureAwait(false);
+
+        stopwatch.Stop();
+        _logger.LogInformation("Subtree export completed in {Duration}ms. Exported {Count} nodes to {File}.",
+            stopwatch.ElapsedMilliseconds, combinedNodes.Count, filePath);
+
+        return filePath;
+    }
+
+    /// <summary>
+    /// Fetches all nodes in the subtree starting from the given node via hierarchical references.
+    /// Includes the start node itself.
+    /// </summary>
+    private async Task<IList<INode>> FetchSubtreeNodesAsync(
+        ExpandedNodeId startNodeId,
+        CancellationToken cancellationToken)
+    {
+        return await _client.ExecuteWithRetryAsync(async (session, ct) =>
+        {
+            var stopwatch = Stopwatch.StartNew();
+            var nodeDictionary = new Dictionary<ExpandedNodeId, INode>();
+            var references = new NodeIdCollection { ReferenceTypeIds.HierarchicalReferences };
+            var nodesToBrowse = new ExpandedNodeIdCollection { startNodeId };
+
+            session.NodeCache.Clear();
+            await FetchReferenceIdTypesAsync(session, ct).ConfigureAwait(false);
+
+            // Add the start node itself
+            var startNode = await session.NodeCache.FindAsync(startNodeId, ct).ConfigureAwait(false);
+            if (startNode != null)
+            {
+                nodeDictionary[startNode.NodeId] = startNode;
+            }
+
+            int searchDepth = 0;
+            while (nodesToBrowse.Count > 0 && searchDepth < MaxSearchDepth)
+            {
+                ct.ThrowIfCancellationRequested();
+
+                searchDepth++;
+                _logger.LogInformation("Subtree depth {Depth}: Browsing {Count} nodes ({Elapsed}ms)...",
+                    searchDepth, nodesToBrowse.Count, stopwatch.ElapsedMilliseconds);
+
+                var response = await session.NodeCache.FindReferencesAsync(
+                    nodesToBrowse, references, false, true, ct).ConfigureAwait(false);
+
+                var nextNodesToBrowse = new ExpandedNodeIdCollection();
+                int duplicates = 0;
+
+                foreach (var node in response)
+                {
+                    if (!nodeDictionary.ContainsKey(node.NodeId))
+                    {
+                        nodeDictionary[node.NodeId] = node;
+
+                        bool isLeafNode = false;
+                        if (node is VariableNode variableNode)
+                        {
+                            var hasTypeDefinition = variableNode.ReferenceTable
+                                .FirstOrDefault(r => r.ReferenceTypeId.Equals(ReferenceTypeIds.HasTypeDefinition));
+                            if (hasTypeDefinition != null)
+                            {
+                                isLeafNode = hasTypeDefinition.TargetId == VariableTypeIds.PropertyType;
+                            }
+                        }
+
+                        if (!isLeafNode)
+                        {
+                            nextNodesToBrowse.Add(node.NodeId);
+                        }
+                    }
+                    else
+                    {
+                        duplicates++;
+                    }
+                }
+
+                if (duplicates > 0)
+                {
+                    _logger.LogDebug("Skipped {Count} duplicate nodes.", duplicates);
+                }
+
+                nodesToBrowse = nextNodesToBrowse;
+            }
+
+            stopwatch.Stop();
+
+            var result = nodeDictionary.Values.ToList();
+            result.Sort((x, y) => x.NodeId.CompareTo(y.NodeId));
+
+            _logger.LogInformation("FetchSubtreeNodes found {Count} nodes in {Duration}ms.",
+                result.Count, stopwatch.ElapsedMilliseconds);
+
+            if (_verbose)
+            {
+                foreach (var node in result.Take(100))
+                {
+                    _logger.LogDebug("Node: {NodeId} ({NodeClass}) - {BrowseName}",
+                        node.NodeId, node.NodeClass, node.BrowseName);
+                }
+                if (result.Count > 100)
+                {
+                    _logger.LogDebug("... and {Count} more nodes.", result.Count - 100);
+                }
+            }
+
+            return (IList<INode>)result;
+        }, "FetchSubtreeNodes", cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Collects type definitions used by the subtree nodes that are in the specified namespace.
+    /// Also includes supertypes in the same namespace to ensure a valid type hierarchy.
+    /// </summary>
+    private async Task<IList<INode>> CollectUsedTypeDefinitionsAsync(
+        IList<INode> subtreeNodes,
+        ushort targetNamespaceIndex,
+        CancellationToken cancellationToken)
+    {
+        return await _client.ExecuteWithRetryAsync(async (session, ct) =>
+        {
+            var typeDefNodes = new Dictionary<ExpandedNodeId, INode>();
+            var processedTypeIds = new HashSet<ExpandedNodeId>();
+
+            // Collect all type definition IDs referenced by subtree nodes
+            var typeDefIdsToResolve = new HashSet<ExpandedNodeId>();
+            foreach (var node in subtreeNodes)
+            {
+                var typeDefId = node.TypeDefinitionId;
+                if (!NodeId.IsNull(typeDefId) && typeDefId.NamespaceIndex == targetNamespaceIndex)
+                {
+                    typeDefIdsToResolve.Add(typeDefId);
+                }
+            }
+
+            _logger.LogDebug("Found {Count} unique type definition references in target namespace.",
+                typeDefIdsToResolve.Count);
+
+            // Resolve type definitions and walk the supertype chain
+            while (typeDefIdsToResolve.Count > 0)
+            {
+                ct.ThrowIfCancellationRequested();
+
+                var currentBatch = typeDefIdsToResolve.ToList();
+                typeDefIdsToResolve.Clear();
+
+                foreach (var typeDefId in currentBatch)
+                {
+                    if (processedTypeIds.Contains(typeDefId))
+                    {
+                        continue;
+                    }
+                    processedTypeIds.Add(typeDefId);
+
+                    // Fetch the type definition node
+                    var typeNode = await session.NodeCache.FindAsync(typeDefId, ct).ConfigureAwait(false);
+                    if (typeNode == null)
+                    {
+                        _logger.LogWarning("Could not find type definition node {TypeDefId}", typeDefId);
+                        continue;
+                    }
+
+                    typeDefNodes[typeNode.NodeId] = typeNode;
+
+                    if (_verbose)
+                    {
+                        _logger.LogDebug("Included type definition: {NodeId} ({BrowseName})",
+                            typeNode.NodeId, typeNode.BrowseName);
+                    }
+
+                    // Walk the supertype chain: find the parent type via HasSubtype inverse
+                    var supertypes = await session.NodeCache.FindReferencesAsync(
+                        typeDefId,
+                        ReferenceTypeIds.HasSubtype,
+                        true, // isInverse = true → finds the parent/supertype
+                        false,
+                        ct).ConfigureAwait(false);
+
+                    foreach (var supertype in supertypes)
+                    {
+                        if (supertype.NodeId.NamespaceIndex == targetNamespaceIndex &&
+                            !processedTypeIds.Contains(supertype.NodeId))
+                        {
+                            typeDefIdsToResolve.Add(supertype.NodeId);
+                        }
+                    }
+
+                    // Also collect child nodes of the type definition (components, properties)
+                    // that are in the same namespace, so the type definition is complete
+                    var typeChildren = await session.NodeCache.FindReferencesAsync(
+                        typeDefId,
+                        ReferenceTypeIds.HierarchicalReferences,
+                        false,
+                        true,
+                        ct).ConfigureAwait(false);
+
+                    foreach (var child in typeChildren)
+                    {
+                        if (child.NodeId.NamespaceIndex == targetNamespaceIndex &&
+                            !typeDefNodes.ContainsKey(child.NodeId))
+                        {
+                            typeDefNodes[child.NodeId] = child;
+                        }
+                    }
+                }
+            }
+
+            var result = typeDefNodes.Values.ToList();
+            _logger.LogInformation("Collected {Count} type definition nodes (including supertypes and children) in namespace {Namespace}.",
+                result.Count, targetNamespaceIndex);
+
+            return (IList<INode>)result;
+        }, "CollectUsedTypeDefinitions", cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
     /// Loads the complex type system from the server.
     /// </summary>
     private async Task LoadTypeSystemAsync(CancellationToken cancellationToken)

--- a/src/OpcUaNodesetExporter/OpcUa/OpcUaClientBuilder.cs
+++ b/src/OpcUaNodesetExporter/OpcUa/OpcUaClientBuilder.cs
@@ -352,7 +352,24 @@ public class OpcUaClientBuilder
 
         // Select the best matching endpoint
         var selectedEndpoint = SelectBestEndpoint(endpointCollection);
-        _logger.LogDebug("Discovered endpoint URL: {DiscoveredUrl}. User provided URL: {OriginalUrl}", selectedEndpoint.EndpointUrl, _endpoint);
+        var discoveredEndpointUrl = selectedEndpoint.EndpointUrl;
+        var effectiveEndpointUrl = GetEffectiveSessionEndpointUrl(endpointUrl, discoveredEndpointUrl);
+
+        if (!string.Equals(discoveredEndpointUrl, effectiveEndpointUrl, StringComparison.OrdinalIgnoreCase))
+        {
+            _logger.LogInformation(
+                "Using requested endpoint authority for session. Requested: {RequestedUrl}, Discovered: {DiscoveredUrl}, Effective: {EffectiveUrl}",
+                _endpoint,
+                discoveredEndpointUrl,
+                effectiveEndpointUrl);
+        }
+
+        selectedEndpoint.EndpointUrl = effectiveEndpointUrl;
+        _logger.LogDebug(
+            "Requested endpoint URL: {RequestedUrl}. Discovered endpoint URL: {DiscoveredUrl}. Effective session endpoint URL: {EffectiveUrl}",
+            _endpoint,
+            discoveredEndpointUrl,
+            effectiveEndpointUrl);
 
         // If the selected endpoint requires security, ensure we have a certificate
         if (selectedEndpoint.SecurityMode != MessageSecurityMode.None && _clientCertificate == null)
@@ -448,6 +465,53 @@ public class OpcUaClientBuilder
         }
 
         throw new ServiceResultException(StatusCodes.BadNoMatch, "No suitable endpoint found on server.");
+    }
+
+    internal static string GetEffectiveSessionEndpointUrl(Uri requestedEndpointUrl, string discoveredEndpointUrl)
+    {
+        if (!Uri.TryCreate(discoveredEndpointUrl, UriKind.Absolute, out var discoveredEndpointUri))
+        {
+            return requestedEndpointUrl.AbsoluteUri;
+        }
+
+        var hasRequestedPath =
+            !string.IsNullOrEmpty(requestedEndpointUrl.AbsolutePath) &&
+            !string.Equals(requestedEndpointUrl.AbsolutePath, "/", StringComparison.Ordinal);
+        var hasRequestedQuery = !string.IsNullOrEmpty(requestedEndpointUrl.Query);
+        var authorityDiffers = !UrisShareAuthority(requestedEndpointUrl, discoveredEndpointUri);
+
+        if (!authorityDiffers && !hasRequestedPath && !hasRequestedQuery)
+        {
+            return discoveredEndpointUri.AbsoluteUri;
+        }
+
+        var builder = new UriBuilder(discoveredEndpointUri);
+
+        if (authorityDiffers)
+        {
+            builder.Scheme = requestedEndpointUrl.Scheme;
+            builder.Host = requestedEndpointUrl.Host;
+            builder.Port = requestedEndpointUrl.Port;
+        }
+
+        if (hasRequestedPath)
+        {
+            builder.Path = requestedEndpointUrl.AbsolutePath;
+        }
+
+        if (hasRequestedQuery)
+        {
+            builder.Query = requestedEndpointUrl.Query.TrimStart('?');
+        }
+
+        return builder.Uri.AbsoluteUri;
+    }
+
+    private static bool UrisShareAuthority(Uri requestedEndpointUrl, Uri discoveredEndpointUri)
+    {
+        return string.Equals(requestedEndpointUrl.Scheme, discoveredEndpointUri.Scheme, StringComparison.OrdinalIgnoreCase) &&
+               string.Equals(requestedEndpointUrl.Host, discoveredEndpointUri.Host, StringComparison.OrdinalIgnoreCase) &&
+               requestedEndpointUrl.Port == discoveredEndpointUri.Port;
     }
 
     private UserIdentity CreateUserIdentity()

--- a/src/OpcUaNodesetExporter/Properties/AssemblyInfo.cs
+++ b/src/OpcUaNodesetExporter/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("OpcUaNodesetExporter.Tests")]

--- a/tests/OpcUaNodesetExporter.AppHost/Program.cs
+++ b/tests/OpcUaNodesetExporter.AppHost/Program.cs
@@ -13,15 +13,44 @@ Directory.CreateDirectory(exportFolder);
 
 // Add umati OPC UA sample server container
 var umatiServer = builder
-    .AddContainer("opcplc", "ghcr.io/umati/sample-server", "develop")
-    .WithEndpoint(port: 50000, targetPort: 4840, scheme: "opc.tcp", name: "opcua");
+    .AddContainer("umati", "ghcr.io/umati/sample-server", "develop")
+    .WithEndpoint(port: 50002, targetPort: 4840, scheme: "opc.tcp", name: "opcua");
 
 // Get the OPC UA endpoint for reference
 var umatiServerEndpoint = umatiServer.GetEndpoint("opcua");
 
+// Add OPC PLC server container
+var opcplc = builder
+    .AddContainer("opcplc", "mcr.microsoft.com/iotedge/opc-plc", "latest")
+    .WithEndpoint(port: 50000, targetPort: 50000, scheme: "opc.tcp", name: "opcua")
+    .WithArgs("--ph=localhost")
+    .WithArgs("--cdn=localhost,opcplc") 
+    .WithArgs("--autoaccept") 
+    .WithArgs("--sn=25") 
+    .WithArgs("--sr=10") 
+    .WithArgs("--fn=2000") 
+    .WithArgs("--veryfastrate=1000") 
+    .WithArgs("--gn=5") 
+    .WithArgs("--pn=50000")
+    .WithArgs("--maxsessioncount=100") 
+    .WithArgs("--maxsubscriptioncount=100") 
+    .WithArgs("--maxqueuedrequestcount=2000") 
+    .WithArgs("--ses") 
+    .WithArgs("--alm") 
+    .WithArgs("--at=FlatDirectory") 
+    .WithArgs("--drurs");
+
+// Get the OPC UA endpoint for reference
+var opcPlcEndpoint = opcplc.GetEndpoint("opcua");
+
 // Add the OpcUaNodesetExporter project with the endpoint and output folder injected
-builder.AddProject<OpcUaNodesetExporter>("opcua-nodeset-exporter")
+builder.AddProject<OpcUaNodesetExporter>("umati-opcua-nodeset-exporter")
     .WithEnvironment("OPCUA_ENDPOINT", umatiServerEndpoint)
+    .WithArgs("--output", exportFolder);
+
+builder.AddProject<OpcUaNodesetExporter>("opcplc-opcua-nodeset-exporter")
+    .WithEnvironment("OPCUA_ENDPOINT", opcPlcEndpoint)
+    .WithEnvironment("OPCUA_START_NODE", "nsu=http://microsoft.com/Opc/OpcPlc/Boiler;i=5017")
     .WithArgs("--output", exportFolder);
 
 builder.Build().Run();

--- a/tests/OpcUaNodesetExporter.Tests/IntegrationTests.cs
+++ b/tests/OpcUaNodesetExporter.Tests/IntegrationTests.cs
@@ -134,4 +134,128 @@ public class IntegrationTests : IAsyncLifetime
             }
         }
     }
+
+    [Fact]
+    public async Task CanExportSubtree()
+    {
+        Assert.NotNull(_opcUaEndpoint);
+
+        // Arrange
+        using var loggerFactory = LoggerFactory.Create(builder =>
+        {
+            builder.AddConsole();
+            builder.SetMinimumLevel(LogLevel.Information);
+        });
+
+        var tempDir = Path.Combine(Path.GetTempPath(), "opcua-subtree-test-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            var options = new OpcUaClientOptions
+            {
+                Endpoint = _opcUaEndpoint,
+                RetryCount = 3,
+                RetryDelaySeconds = 5
+            };
+
+            await using var client = await OpcUaClientBuilder
+                .Create(loggerFactory)
+                .FromOptions(options)
+                .TrustAllServerCertificates()
+                .ConnectAsync();
+
+            var exporter = new NodeSetExporter(
+                loggerFactory.CreateLogger<NodeSetExporter>(),
+                loggerFactory,
+                client,
+                verbose: true);
+
+            // Use the Boiler namespace's "Boilers" folder node (ns=4;i=5) as start node
+            // This is a known node in the OPC PLC simulator
+            var startNodeId = Opc.Ua.ExpandedNodeId.Parse("ns=4;i=5", client.Session.NamespaceUris);
+
+            // Act
+            var exportedFile = await exporter.ExportSubtreeAsync(startNodeId, tempDir);
+
+            // Assert
+            Assert.NotNull(exportedFile);
+            Assert.True(File.Exists(exportedFile));
+
+            // Verify the output is valid XML with UANodeSet root element
+            var xmlContent = await File.ReadAllTextAsync(exportedFile);
+            Assert.Contains("<UANodeSet", xmlContent);
+            Assert.Contains("</UANodeSet>", xmlContent);
+
+            // Verify it contains at least one node from the subtree
+            Assert.Contains("Boiler", xmlContent);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                Directory.Delete(tempDir, true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task SubtreeExportExcludesTypesFromOtherNamespaces()
+    {
+        Assert.NotNull(_opcUaEndpoint);
+
+        // Arrange
+        using var loggerFactory = LoggerFactory.Create(builder =>
+        {
+            builder.AddConsole();
+            builder.SetMinimumLevel(LogLevel.Information);
+        });
+
+        var tempDir = Path.Combine(Path.GetTempPath(), "opcua-subtree-filter-test-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            var options = new OpcUaClientOptions
+            {
+                Endpoint = _opcUaEndpoint,
+                RetryCount = 3,
+                RetryDelaySeconds = 5
+            };
+
+            await using var client = await OpcUaClientBuilder
+                .Create(loggerFactory)
+                .FromOptions(options)
+                .TrustAllServerCertificates()
+                .ConnectAsync();
+
+            var exporter = new NodeSetExporter(
+                loggerFactory.CreateLogger<NodeSetExporter>(),
+                loggerFactory,
+                client,
+                verbose: true);
+
+            // Use the Boiler namespace's "Boilers" folder node (ns=4;i=5)
+            var startNodeId = Opc.Ua.ExpandedNodeId.Parse("ns=4;i=5", client.Session.NamespaceUris);
+
+            // Act
+            var exportedFile = await exporter.ExportSubtreeAsync(startNodeId, tempDir);
+
+            // Assert
+            Assert.True(File.Exists(exportedFile));
+            var xmlContent = await File.ReadAllTextAsync(exportedFile);
+
+            // The export should reference other namespaces in the NamespaceUris section
+            // but should NOT include UAObjectType/UAVariableType nodes from namespace 0
+            // (OPC UA base types like BaseObjectType are ns=0 and should not be exported as nodes)
+            Assert.DoesNotContain("NodeId=\"i=", xmlContent); // No ns=0 node definitions
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                Directory.Delete(tempDir, true);
+            }
+        }
+    }
 }

--- a/tests/OpcUaNodesetExporter.Tests/OpcUaClientBuilderTests.cs
+++ b/tests/OpcUaNodesetExporter.Tests/OpcUaClientBuilderTests.cs
@@ -1,0 +1,39 @@
+using OpcUaNodesetExporter.OpcUa;
+
+namespace OpcUaNodesetExporter.Tests;
+
+public class OpcUaClientBuilderTests
+{
+    [Fact]
+    public void GetEffectiveSessionEndpointUrl_RewritesAuthority_WhenServerAdvertisesInternalEndpoint()
+    {
+        var requestedEndpoint = new Uri("opc.tcp://localhost:50001");
+        const string discoveredEndpoint = "opc.tcp://opcplc:50000/UA/PLC";
+
+        var effectiveEndpoint = OpcUaClientBuilder.GetEffectiveSessionEndpointUrl(requestedEndpoint, discoveredEndpoint);
+
+        Assert.Equal("opc.tcp://localhost:50001/UA/PLC", effectiveEndpoint);
+    }
+
+    [Fact]
+    public void GetEffectiveSessionEndpointUrl_PreservesDiscoveredPath_WhenAuthorityAlreadyMatches()
+    {
+        var requestedEndpoint = new Uri("opc.tcp://localhost:50000");
+        const string discoveredEndpoint = "opc.tcp://localhost:50000/UA/Server";
+
+        var effectiveEndpoint = OpcUaClientBuilder.GetEffectiveSessionEndpointUrl(requestedEndpoint, discoveredEndpoint);
+
+        Assert.Equal(discoveredEndpoint, effectiveEndpoint);
+    }
+
+    [Fact]
+    public void GetEffectiveSessionEndpointUrl_PrefersRequestedPath_WhenCallerSuppliesOne()
+    {
+        var requestedEndpoint = new Uri("opc.tcp://localhost:50001/custom/path");
+        const string discoveredEndpoint = "opc.tcp://opcplc:50000/UA/PLC";
+
+        var effectiveEndpoint = OpcUaClientBuilder.GetEffectiveSessionEndpointUrl(requestedEndpoint, discoveredEndpoint);
+
+        Assert.Equal("opc.tcp://localhost:50001/custom/path", effectiveEndpoint);
+    }
+}


### PR DESCRIPTION
Adds --start-node/-s and OPCUA_START_NODE for subtree export, enabling partial address space export with type filtering by namespace. Improves endpoint URL handling for container/proxy scenarios. Updates README, adds unit/integration tests, and expands test harness for OPC PLC server.