### PR TITLE
Add --export-attributes option with JSON diagnostics

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ A .NET global tool that connects to an OPC UA server and exports all custom name
 - 🔄 Automatic reconnection with configurable retry logic
 - 🖥️ Cross-platform (Windows, Linux, macOS)
 - 📝 Credential input via stdin for CI/CD pipelines
+- 🩺 Optional attribute diagnostics (`--export-attributes`): JSON sidecar with
+  every standard attribute (incl. `Value`) and its `StatusCode` per node
 
 ## Installation
 
@@ -61,6 +63,8 @@ Options:
       --keep-alive <seconds>          Keep-alive interval in seconds [default: 5]
       --session-timeout <seconds>     Session timeout in seconds [default: 120]
       --keep-alive-threshold <count>  Missed keep-alives before reconnect [default: 3]
+      --export-attributes             Read all standard attributes (incl. Value) and write a JSON
+                                      sidecar per NodeSet2 file with attribute values and status codes
   -v, --verbose                       Enable verbose logging
   -?, -h, --help                      Show help and usage information
 ```
@@ -109,6 +113,58 @@ The output is a single NodeSet2 XML file containing:
 - The start node and all its subnodes (via hierarchical references)
 - Type definitions used by the subtree that are in the same namespace as the start node
 - Supertypes of included types (if also in the same namespace)
+
+### Diagnostic Attribute Export (`--export-attributes`)
+
+By default the exporter populates only the attributes that the OPC UA Browse
+service returns. Every other attribute (such as `Value`, `ValueRank`,
+`MinimumSamplingInterval`, `DataType`, `AccessLevel`, ...) is re-read from
+the server before serialization, so the produced NodeSet2 XML reflects the
+real address space — `ValueRank="-2"` and `MinimumSamplingInterval="-1"` no
+longer leak through as the SDK's in-memory defaults.
+
+`--export-attributes` additionally:
+
+- Reads the `Value` attribute of every Variable / VariableType node, so the
+  NodeSet2 XML contains a `<Value>` element when the server returned data.
+- Writes a JSON diagnostic file alongside each NodeSet2 XML named
+  `<namespace>_attributes.json`. The file records every attribute relevant to
+  each node's `NodeClass` together with the OPC UA `StatusCode` returned by
+  the server. This makes it easy to spot variables that have an empty value,
+  return `BadAttributeIdInvalid`, or otherwise fail to read.
+
+```bash
+# Full export with attribute diagnostics
+opcua-nodeset-export -e opc.tcp://localhost:4840 --export-attributes
+
+# Subtree export with diagnostics (works in both modes)
+opcua-nodeset-export -e opc.tcp://localhost:4840 -s "ns=4;i=5" --export-attributes
+```
+
+Example excerpt of `<namespace>_attributes.json`:
+
+```json
+{
+  "namespaceUri": "http://example.com/devices/",
+  "namespaceIndex": 4,
+  "exportedAt": "2026-06-10T18:42:00Z",
+  "nodes": [
+    {
+      "nodeId": "ns=4;i=1234",
+      "browseName": "4:MyVar",
+      "displayName": "MyVar",
+      "nodeClass": "Variable",
+      "attributes": {
+        "Value":                   { "status": "Good",             "statusCode": "0x00000000", "value": 42 },
+        "DataType":                { "status": "Int32",            "statusCode": "0x00000000", "value": "i=6" },
+        "ValueRank":               { "status": "Good",             "statusCode": "0x00000000", "value": -1 },
+        "AccessLevel":             { "status": "Good",             "statusCode": "0x00000000", "value": 3 },
+        "MinimumSamplingInterval": { "status": "BadNotReadable",   "statusCode": "0x803A0000", "value": null }
+      }
+    }
+  ]
+}
+```
 
 ### Secure Connection
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ Options:
       --keep-alive-threshold <count>  Missed keep-alives before reconnect [default: 3]
       --export-attributes             Read all standard attributes (incl. Value) and write a JSON
                                       sidecar per NodeSet2 file with attribute values and status codes
+      --log-file <path>               Also append all log output to this file (Debug level when
+                                      --verbose is set, otherwise Information). Parent directories
+                                      are created on demand.
   -v, --verbose                       Enable verbose logging
   -?, -h, --help                      Show help and usage information
 ```
@@ -81,6 +84,7 @@ The following environment variables can be used to configure the tool:
 | `OPCUA_PASSWORD` | Password for authentication | `--password` |
 | `OPCUA_CERTIFICATE_PATH` | Path to client certificate | `--certificate-path` |
 | `OPCUA_CERTIFICATE_PASSWORD` | Client certificate password | `--certificate-password` |
+| `OPCUA_LOG_FILE` | Optional log file path | `--log-file` |
 
 ## Examples
 
@@ -345,6 +349,9 @@ dotnet test --filter "Category=Integration"
 ```bash
 # Enable verbose logging
 opcua-nodeset-export -e opc.tcp://server:4840 --verbose
+
+# Capture verbose log output to a file (in addition to the console)
+opcua-nodeset-export -e opc.tcp://server:4840 --verbose --log-file ./logs/export.log
 ```
 
 ### Certificate Errors

--- a/src/OpcUaNodesetExporter/Commands/ExportCommand.cs
+++ b/src/OpcUaNodesetExporter/Commands/ExportCommand.cs
@@ -144,6 +144,13 @@ public class ExportCommand : RootCommand
             DefaultValueFactory = (_) => false
         };
 
+        var logFileOption = new Option<string?>(
+            name: "--log-file")
+        {
+            Description = "Optional path to a log file. All log output (Debug level when --verbose is set, otherwise Information) is appended to this file in addition to the console. Parent directories are created on demand.",
+            DefaultValueFactory = (_) => EnvironmentVariables.GetValue(EnvironmentVariables.LogFile)
+        };
+
         // Add all options
         Options.Add(endpointOption);
         Options.Add(securityModeOption);
@@ -161,6 +168,7 @@ public class ExportCommand : RootCommand
         Options.Add(verboseOption);
         Options.Add(startNodeOption);
         Options.Add(exportAttributesOption);
+        Options.Add(logFileOption);
 
         this.SetAction(async (parseResult, cancellationToken) =>
         {
@@ -180,6 +188,7 @@ public class ExportCommand : RootCommand
             var verbose = parseResult.GetValue(verboseOption);
             var startNode = parseResult.GetValue(startNodeOption);
             var exportAttributes = parseResult.GetValue(exportAttributesOption);
+            var logFile = parseResult.GetValue(logFileOption);
 
             return await ExecuteAsync(
                 endpoint,
@@ -198,6 +207,7 @@ public class ExportCommand : RootCommand
                 verbose,
                 startNode,
                 exportAttributes,
+                logFile,
                 cancellationToken);
         });
     }
@@ -219,13 +229,19 @@ public class ExportCommand : RootCommand
         bool verbose,
         string? startNode,
         bool exportAttributes,
+        string? logFile,
         CancellationToken cancellationToken)
     {
         // Configure logging
+        var minLevel = verbose ? LogLevel.Debug : LogLevel.Information;
         using var loggerFactory = LoggerFactory.Create(builder =>
         {
             builder.AddConsole();
-            builder.SetMinimumLevel(verbose ? LogLevel.Debug : LogLevel.Information);
+            builder.SetMinimumLevel(minLevel);
+            if (!string.IsNullOrWhiteSpace(logFile))
+            {
+                builder.AddProvider(new Logging.FileLoggerProvider(logFile, minLevel));
+            }
         });
 
         var logger = loggerFactory.CreateLogger<ExportCommand>();
@@ -286,7 +302,8 @@ public class ExportCommand : RootCommand
                 RetryCount = retryCount,
                 RetryDelaySeconds = retryDelay,
                 Verbose = verbose,
-                ExportAttributes = exportAttributes
+                ExportAttributes = exportAttributes,
+                LogFile = logFile
             };
 
             // Validate authentication requirements
@@ -317,6 +334,10 @@ public class ExportCommand : RootCommand
             if (options.ExportAttributes)
             {
                 logger.LogInformation("Attribute export: enabled (Value reads + JSON sidecars)");
+            }
+            if (!string.IsNullOrWhiteSpace(options.LogFile))
+            {
+                logger.LogInformation("Log file: {LogFile}", Path.GetFullPath(options.LogFile));
             }
             logger.LogInformation("");
 

--- a/src/OpcUaNodesetExporter/Commands/ExportCommand.cs
+++ b/src/OpcUaNodesetExporter/Commands/ExportCommand.cs
@@ -137,6 +137,13 @@ public class ExportCommand : RootCommand
             DefaultValueFactory = (_) => EnvironmentVariables.GetValue(EnvironmentVariables.StartNode)
         };
 
+        var exportAttributesOption = new Option<bool>(
+            name: "--export-attributes")
+        {
+            Description = "Read all standard attributes (incl. Value for variables) and write a JSON sidecar per NodeSet2 file with attribute values and status codes. Useful for detecting empty/unreadable values.",
+            DefaultValueFactory = (_) => false
+        };
+
         // Add all options
         Options.Add(endpointOption);
         Options.Add(securityModeOption);
@@ -153,6 +160,7 @@ public class ExportCommand : RootCommand
         Options.Add(retryDelayOption);
         Options.Add(verboseOption);
         Options.Add(startNodeOption);
+        Options.Add(exportAttributesOption);
 
         this.SetAction(async (parseResult, cancellationToken) =>
         {
@@ -171,6 +179,7 @@ public class ExportCommand : RootCommand
             var retryDelay = parseResult.GetValue(retryDelayOption);
             var verbose = parseResult.GetValue(verboseOption);
             var startNode = parseResult.GetValue(startNodeOption);
+            var exportAttributes = parseResult.GetValue(exportAttributesOption);
 
             return await ExecuteAsync(
                 endpoint,
@@ -188,6 +197,7 @@ public class ExportCommand : RootCommand
                 retryDelay,
                 verbose,
                 startNode,
+                exportAttributes,
                 cancellationToken);
         });
     }
@@ -208,6 +218,7 @@ public class ExportCommand : RootCommand
         int retryDelay,
         bool verbose,
         string? startNode,
+        bool exportAttributes,
         CancellationToken cancellationToken)
     {
         // Configure logging
@@ -274,7 +285,8 @@ public class ExportCommand : RootCommand
                 OutputDirectory = output,
                 RetryCount = retryCount,
                 RetryDelaySeconds = retryDelay,
-                Verbose = verbose
+                Verbose = verbose,
+                ExportAttributes = exportAttributes
             };
 
             // Validate authentication requirements
@@ -302,6 +314,10 @@ public class ExportCommand : RootCommand
             logger.LogInformation("Security Policy: {SecurityPolicy}", options.SecurityPolicy);
             logger.LogInformation("Authentication: {AuthMode}", options.AuthMode);
             logger.LogInformation("Output Directory: {Output}", options.OutputDirectory);
+            if (options.ExportAttributes)
+            {
+                logger.LogInformation("Attribute export: enabled (Value reads + JSON sidecars)");
+            }
             logger.LogInformation("");
 
             // Connect to server
@@ -320,7 +336,8 @@ public class ExportCommand : RootCommand
                 loggerFactory.CreateLogger<NodeSetExporter>(),
                 loggerFactory,
                 client,
-                options.Verbose);
+                options.Verbose,
+                options.ExportAttributes);
 
             if (!string.IsNullOrEmpty(startNode))
             {

--- a/src/OpcUaNodesetExporter/Configuration/EnvironmentVariables.cs
+++ b/src/OpcUaNodesetExporter/Configuration/EnvironmentVariables.cs
@@ -36,6 +36,14 @@ public static class EnvironmentVariables
     public const string StartNode = "OPCUA_START_NODE";
 
     /// <summary>
+    /// Environment variable for the optional log file path. When set, all log
+    /// output (at <c>--verbose</c> level when verbose is enabled, otherwise
+    /// <c>Information</c>) is also written to this file in addition to the
+    /// console.
+    /// </summary>
+    public const string LogFile = "OPCUA_LOG_FILE";
+
+    /// <summary>
     /// Gets the value of an environment variable, returning null if not set or empty.
     /// </summary>
     /// <param name="variableName">The name of the environment variable.</param>

--- a/src/OpcUaNodesetExporter/Logging/FileLoggerProvider.cs
+++ b/src/OpcUaNodesetExporter/Logging/FileLoggerProvider.cs
@@ -1,0 +1,154 @@
+using System.Globalization;
+using System.Text;
+using Microsoft.Extensions.Logging;
+
+namespace OpcUaNodesetExporter.Logging;
+
+/// <summary>
+/// Minimal file <see cref="ILoggerProvider"/>. Writes every log entry from
+/// every category as a single, timestamped, plain-text line. Intended for
+/// diagnostic capture of verbose runs (e.g. <c>--log-file diag.log</c>) without
+/// pulling in a third-party logging package.
+/// </summary>
+/// <remarks>
+/// <para>Thread-safe: a single <see cref="object"/> gate serialises writes to
+/// the underlying <see cref="StreamWriter"/>.</para>
+/// <para>The provider honours its own <see cref="LogLevel"/> filter so the file
+/// can capture <c>Debug</c>/<c>Trace</c> even when the console provider is
+/// configured at <c>Information</c>, and vice versa.</para>
+/// </remarks>
+public sealed class FileLoggerProvider : ILoggerProvider
+{
+    private readonly StreamWriter _writer;
+    private readonly object _gate = new();
+    private readonly LogLevel _minLevel;
+    private bool _disposed;
+
+    /// <summary>
+    /// Creates a new <see cref="FileLoggerProvider"/> that appends to (or
+    /// creates) the given <paramref name="path"/>. Parent directories are
+    /// created on demand.
+    /// </summary>
+    /// <param name="path">Target log file path (relative or absolute).</param>
+    /// <param name="minLevel">Minimum level a log entry must meet to be written.</param>
+    /// <param name="append">When <c>true</c>, append to an existing file; otherwise overwrite.</param>
+    public FileLoggerProvider(string path, LogLevel minLevel = LogLevel.Trace, bool append = true)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            throw new ArgumentException("Log file path must not be empty.", nameof(path));
+        }
+
+        var fullPath = Path.GetFullPath(path);
+        var directory = Path.GetDirectoryName(fullPath);
+        if (!string.IsNullOrEmpty(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        var stream = new FileStream(
+            fullPath,
+            append ? FileMode.Append : FileMode.Create,
+            FileAccess.Write,
+            FileShare.Read);
+
+        _writer = new StreamWriter(stream, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false))
+        {
+            AutoFlush = true,
+        };
+        _minLevel = minLevel;
+        FilePath = fullPath;
+    }
+
+    /// <summary>Gets the absolute path the provider is writing to.</summary>
+    public string FilePath { get; }
+
+    /// <inheritdoc />
+    public ILogger CreateLogger(string categoryName) =>
+        new FileLogger(categoryName, _writer, _gate, _minLevel);
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        lock (_gate)
+        {
+            _writer.Flush();
+            _writer.Dispose();
+        }
+    }
+
+    private sealed class FileLogger : ILogger
+    {
+        private readonly string _category;
+        private readonly StreamWriter _writer;
+        private readonly object _gate;
+        private readonly LogLevel _minLevel;
+
+        public FileLogger(string category, StreamWriter writer, object gate, LogLevel minLevel)
+        {
+            _category = category;
+            _writer = writer;
+            _gate = gate;
+            _minLevel = minLevel;
+        }
+
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+
+        public bool IsEnabled(LogLevel logLevel) =>
+            logLevel != LogLevel.None && logLevel >= _minLevel;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            if (!IsEnabled(logLevel))
+            {
+                return;
+            }
+
+            var message = formatter(state, exception);
+            if (string.IsNullOrEmpty(message) && exception is null)
+            {
+                return;
+            }
+
+            var line = string.Create(CultureInfo.InvariantCulture,
+                $"{DateTime.UtcNow:O} [{LevelToken(logLevel)}] {_category}: {message}");
+
+            lock (_gate)
+            {
+                _writer.WriteLine(line);
+                if (exception is not null)
+                {
+                    _writer.WriteLine(exception);
+                }
+            }
+        }
+
+        private static string LevelToken(LogLevel level) => level switch
+        {
+            LogLevel.Trace => "TRC",
+            LogLevel.Debug => "DBG",
+            LogLevel.Information => "INF",
+            LogLevel.Warning => "WRN",
+            LogLevel.Error => "ERR",
+            LogLevel.Critical => "CRT",
+            _ => "LOG",
+        };
+
+        private sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new();
+            public void Dispose() { }
+        }
+    }
+}

--- a/src/OpcUaNodesetExporter/OpcUa/NodeSetExporter.cs
+++ b/src/OpcUaNodesetExporter/OpcUa/NodeSetExporter.cs
@@ -1,4 +1,8 @@
 using System.Diagnostics;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Xml;
 using Microsoft.Extensions.Logging;
 using Opc.Ua;
 using Opc.Ua.Client;
@@ -13,11 +17,13 @@ namespace OpcUaNodesetExporter.OpcUa;
 public class NodeSetExporter
 {
     private const int MaxSearchDepth = 128;
+    private const uint DefaultMaxNodesPerRead = 1000;
 
     private readonly ILogger<NodeSetExporter> _logger;
     private readonly ILoggerFactory _loggerFactory;
     private readonly OpcUaClient _client;
     private readonly bool _verbose;
+    private readonly bool _exportAttributes;
 
     /// <summary>
     /// Creates a new NodeSetExporter instance.
@@ -26,12 +32,24 @@ public class NodeSetExporter
     /// <param name="loggerFactory">Logger factory for creating SDK telemetry context.</param>
     /// <param name="client">Connected OPC UA client.</param>
     /// <param name="verbose">Enable verbose output.</param>
-    public NodeSetExporter(ILogger<NodeSetExporter> logger, ILoggerFactory loggerFactory, OpcUaClient client, bool verbose = false)
+    /// <param name="exportAttributes">
+    /// When true, the exporter additionally reads the <c>Value</c> attribute
+    /// for Variable / VariableType nodes (so it is included in the NodeSet2
+    /// XML) and writes a JSON sidecar file per produced NodeSet2 file
+    /// describing every attribute and its status.
+    /// </param>
+    public NodeSetExporter(
+        ILogger<NodeSetExporter> logger,
+        ILoggerFactory loggerFactory,
+        OpcUaClient client,
+        bool verbose = false,
+        bool exportAttributes = false)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
         _client = client ?? throw new ArgumentNullException(nameof(client));
         _verbose = verbose;
+        _exportAttributes = exportAttributes;
     }
 
     /// <summary>
@@ -59,6 +77,12 @@ public class NodeSetExporter
         var nodes = await FetchAllNodesAsync(cancellationToken).ConfigureAwait(false);
 
         _logger.LogInformation("Fetched {Count} nodes from server.", nodes.Count);
+
+        // Read full attribute set per NodeClass so the serialized NodeSet2 XML
+        // contains the actual server-side values for attributes such as
+        // ValueRank, MinimumSamplingInterval, DataType, AccessLevel, etc.,
+        // instead of the SDK's in-memory defaults (e.g. ValueRank = -2).
+        await HydrateNodeAttributesAsync(nodes, cancellationToken).ConfigureAwait(false);
 
         // Export nodes per namespace
         var exportedFiles = await ExportNodesToNodeSet2PerNamespaceAsync(
@@ -120,6 +144,10 @@ public class NodeSetExporter
         var combinedNodes = allNodes.Values.ToList();
         combinedNodes.Sort((x, y) => x.NodeId.CompareTo(y.NodeId));
 
+        // Read full attribute set per NodeClass before serializing so the
+        // NodeSet2 XML reflects real server values instead of SDK defaults.
+        await HydrateNodeAttributesAsync(combinedNodes, cancellationToken).ConfigureAwait(false);
+
         // Generate output file name from the start node
         var session = _client.Session;
         string namespaceUri = session.NamespaceUris.GetString(startNamespaceIndex);
@@ -132,6 +160,16 @@ public class NodeSetExporter
         {
             ExportNodesToNodeSet2File(session, combinedNodes, filePath);
         }, cancellationToken).ConfigureAwait(false);
+
+        if (_exportAttributes)
+        {
+            await WriteAttributesJsonSidecarAsync(
+                combinedNodes,
+                startNamespaceIndex,
+                namespaceUri,
+                filePath,
+                cancellationToken).ConfigureAwait(false);
+        }
 
         stopwatch.Stop();
         _logger.LogInformation("Subtree export completed in {Duration}ms. Exported {Count} nodes to {File}.",
@@ -545,6 +583,16 @@ public class NodeSetExporter
                 ExportNodesToNodeSet2File(session, kvp.Value, filePath);
             }, cancellationToken).ConfigureAwait(false);
 
+            if (_exportAttributes)
+            {
+                await WriteAttributesJsonSidecarAsync(
+                    kvp.Value,
+                    kvp.Key,
+                    namespaceUri,
+                    filePath,
+                    cancellationToken).ConfigureAwait(false);
+            }
+
             exportedFiles[namespaceUri] = filePath;
         }
 
@@ -573,10 +621,19 @@ public class NodeSetExporter
             ServerUris = session.ServerUris
         };
 
-        // Use the OPC Foundation SDK's verified export functionality
-        CoreClientUtils.ExportNodesToNodeSet2(systemContext, nodes, outputStream);
+        // When the user requested attribute export, also ask the SDK to emit
+        // <Value> elements for variables. The default options omit them, which
+        // is why our hydrated Variable.Value would otherwise be silently
+        // discarded by CoreClientUtils.ExportNodesToNodeSet2.
+        var exportOptions = _exportAttributes
+            ? new NodeSetExportOptions { ExportValues = true }
+            : NodeSetExportOptions.Default;
 
-        _logger.LogDebug("Exported {Count} nodes to {FilePath}", nodes.Count, filePath);
+        // Use the OPC Foundation SDK's verified export functionality
+        CoreClientUtils.ExportNodesToNodeSet2(systemContext, nodes, outputStream, exportOptions);
+
+        _logger.LogDebug("Exported {Count} nodes to {FilePath} (ExportValues={ExportValues})",
+            nodes.Count, filePath, exportOptions.ExportValues);
     }
 
     /// <summary>
@@ -621,5 +678,738 @@ public class NodeSetExporter
         }
 
         return $"{fileName}_ns{namespaceIndex}.xml";
+    }
+
+    /// <summary>
+    /// Re-reads the standard attribute set per <see cref="NodeClass"/> for the
+    /// given nodes so that attributes such as <c>ValueRank</c>,
+    /// <c>MinimumSamplingInterval</c>, <c>DataType</c>, <c>AccessLevel</c>,
+    /// etc. reflect actual server values instead of the SDK's in-memory
+    /// defaults that are otherwise present after Browse-driven discovery.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The exporter discovers nodes via <c>NodeCache.FindReferencesAsync</c>,
+    /// which is driven by the Browse service. Browse only returns a subset of
+    /// node attributes; everything else keeps its SDK default
+    /// (e.g. <c>ValueRank == ValueRanks.Any == -2</c>,
+    /// <c>MinimumSamplingInterval == -1</c>). Because
+    /// <c>CoreClientUtils.ExportNodesToNodeSet2</c> writes those in-memory
+    /// values to XML when they differ from the NodeSet2 schema defaults, the
+    /// emitted XML would otherwise show those nonsensical defaults for every
+    /// variable. This method fixes that by issuing raw per-attribute
+    /// <c>Read</c> calls and assigning the returned <see cref="DataValue"/>s
+    /// onto the existing cached <see cref="Node"/> instances.
+    /// </para>
+    /// <para>
+    /// Crucially, the method <strong>mutates the existing cached node</strong>
+    /// rather than replacing it with a freshly-read <see cref="Node"/>: a
+    /// replaced node would lose the references collected by the
+    /// <see cref="NodeCache"/>, which would in turn cause
+    /// <c>CoreClientUtils.ExportNodesToNodeSet2</c> to emit a NodeSet2 file
+    /// without any <c>&lt;References&gt;</c> blocks.
+    /// </para>
+    /// <para>
+    /// When an attribute read returns a <c>Bad</c> status, this method applies
+    /// the NodeSet2 schema default (e.g., <c>ValueRank = -1</c>,
+    /// <c>MinimumSamplingInterval = 0</c>, <c>AccessLevel = 0</c>,
+    /// <c>Historizing = false</c>) instead of leaving the SDK default that
+    /// would otherwise serialise incorrectly.
+    /// </para>
+    /// <para>
+    /// When <see cref="_exportAttributes"/> is set, the <c>Value</c> attribute
+    /// of Variable / VariableType nodes is additionally read and assigned, so
+    /// it is included in the serialized NodeSet2 XML output.
+    /// </para>
+    /// </remarks>
+    private async Task HydrateNodeAttributesAsync(
+        IList<INode> nodes,
+        CancellationToken cancellationToken)
+    {
+        if (nodes.Count == 0)
+        {
+            return;
+        }
+
+        await _client.ExecuteWithRetryAsync(async (session, ct) =>
+        {
+            var stopwatch = Stopwatch.StartNew();
+
+            // Determine read chunk size from the server's reported operation limits.
+            uint maxNodesPerRead = session.OperationLimits?.MaxNodesPerRead ?? 0;
+            int chunkSize = maxNodesPerRead > 0 ? (int)maxNodesPerRead : (int)DefaultMaxNodesPerRead;
+
+            // Build the flat (NodeId, AttributeId, target node) request list.
+            // We assign attribute values onto the existing cached node instance
+            // (which carries the Browse references) instead of replacing it,
+            // so the serialized NodeSet2 XML keeps its <References> blocks.
+            var requests = new List<(NodeId NodeId, uint AttributeId, INode Target)>(nodes.Count * 8);
+
+            foreach (var node in nodes)
+            {
+                if (node.NodeClass == NodeClass.Unspecified)
+                {
+                    continue;
+                }
+
+                var nodeId = ExpandedNodeId.ToNodeId(node.NodeId, session.NamespaceUris);
+                if (nodeId == null)
+                {
+                    continue;
+                }
+
+                foreach (var (attrId, _) in AttributesForNodeClass(node.NodeClass))
+                {
+                    // The Value attribute is only requested in --export-attributes mode:
+                    // it can be expensive to read on large address spaces, and the
+                    // default NodeSet2 export does not need it.
+                    if (attrId == Attributes.Value && !_exportAttributes)
+                    {
+                        continue;
+                    }
+
+                    requests.Add((nodeId, attrId, node));
+                }
+            }
+
+            if (requests.Count == 0)
+            {
+                return;
+            }
+
+            _logger.LogInformation(
+                "Hydrating {Count} (node, attribute) pairs across {NodeCount} nodes (chunk size {Chunk})...",
+                requests.Count, nodes.Count, chunkSize);
+
+            int applied = 0;
+            int unreadable = 0;
+
+            for (int offset = 0; offset < requests.Count; offset += chunkSize)
+            {
+                ct.ThrowIfCancellationRequested();
+                int take = Math.Min(chunkSize, requests.Count - offset);
+
+                var nodesToRead = new ReadValueIdCollection(take);
+                for (int i = 0; i < take; i++)
+                {
+                    nodesToRead.Add(new ReadValueId
+                    {
+                        NodeId = requests[offset + i].NodeId,
+                        AttributeId = requests[offset + i].AttributeId,
+                    });
+                }
+
+                ReadResponse? response = null;
+                try
+                {
+                    response = await session.ReadAsync(
+                        requestHeader: null,
+                        maxAge: 0,
+                        timestampsToReturn: TimestampsToReturn.Neither,
+                        nodesToRead: nodesToRead,
+                        ct: ct).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex,
+                        "Hydration Read chunk of {Count} (node, attribute) pairs failed; affected attributes will get NodeSet2 schema defaults.",
+                        take);
+                }
+
+                for (int i = 0; i < take; i++)
+                {
+                    var req = requests[offset + i];
+                    if (req.Target is not Node nodeImpl)
+                    {
+                        continue;
+                    }
+
+                    DataValue dv;
+                    if (response != null && i < response.Results.Count && response.Results[i] != null)
+                    {
+                        dv = response.Results[i];
+                    }
+                    else
+                    {
+                        dv = new DataValue(StatusCodes.BadCommunicationError);
+                    }
+
+                    if (StatusCode.IsBad(dv.StatusCode))
+                    {
+                        unreadable++;
+                    }
+                    else if (req.AttributeId == Attributes.ValueRank
+                        && dv.WrappedValue.Value is int vrCheck
+                        && vrCheck == ValueRanks.Any)
+                    {
+                        // Helps the user distinguish "hydration didn't run" from
+                        // "server actually returned ValueRank=Any (-2)".
+                        _logger.LogDebug(
+                            "Server returned ValueRank=Any (-2) for {NodeId}; this value will be serialised verbatim.",
+                            req.NodeId);
+                    }
+
+                    ApplyAttributeToNode(nodeImpl, req.AttributeId, dv);
+                    applied++;
+                }
+            }
+
+            stopwatch.Stop();
+            _logger.LogInformation(
+                "Hydrated {Applied} attribute values ({Unreadable} fell back to NodeSet2 schema defaults) in {Duration}ms.",
+                applied, unreadable, stopwatch.ElapsedMilliseconds);
+        }, "HydrateNodeAttributes", cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Applies a single <see cref="DataValue"/> read result onto the
+    /// corresponding attribute of the cached <see cref="Node"/>. On a
+    /// <c>Bad</c> status, the NodeSet2 XML schema default is applied for the
+    /// attributes that would otherwise serialise the SDK's misleading
+    /// in-memory defaults (e.g. <c>ValueRank = -2</c>).
+    /// </summary>
+    /// <remarks>
+    /// Exposed as <c>internal</c> for unit testing — production code calls it
+    /// from <see cref="HydrateNodeAttributesAsync"/>.
+    /// </remarks>
+    internal static void ApplyAttributeToNode(Node node, uint attributeId, DataValue dv)
+    {
+        bool isGood = !StatusCode.IsBad(dv.StatusCode);
+        object? raw = dv.WrappedValue.Value;
+
+        // Common attributes (any node class).
+        switch (attributeId)
+        {
+            case Attributes.Description:
+                if (isGood && raw is LocalizedText desc)
+                {
+                    node.Description = desc;
+                }
+                return;
+            case Attributes.WriteMask:
+                if (isGood && raw is uint wm)
+                {
+                    node.WriteMask = wm;
+                }
+                return;
+            case Attributes.UserWriteMask:
+                if (isGood && raw is uint uwm)
+                {
+                    node.UserWriteMask = uwm;
+                }
+                return;
+            case Attributes.NodeClass:
+            case Attributes.BrowseName:
+            case Attributes.DisplayName:
+                // Already populated from Browse; we don't override the cached values.
+                return;
+        }
+
+        switch (node)
+        {
+            case VariableNode vn:
+                ApplyVariableAttribute(vn, attributeId, dv, isGood, raw);
+                break;
+            case VariableTypeNode vtn:
+                ApplyVariableTypeAttribute(vtn, attributeId, dv, isGood, raw);
+                break;
+            case ObjectNode on:
+                if (attributeId == Attributes.EventNotifier)
+                {
+                    on.EventNotifier = isGood && raw is byte enb ? enb : (byte)0;
+                }
+                break;
+            case ObjectTypeNode otn:
+                if (attributeId == Attributes.IsAbstract && isGood && raw is bool abs)
+                {
+                    otn.IsAbstract = abs;
+                }
+                break;
+            case ReferenceTypeNode rtn:
+                switch (attributeId)
+                {
+                    case Attributes.IsAbstract:
+                        if (isGood && raw is bool absRt)
+                        {
+                            rtn.IsAbstract = absRt;
+                        }
+                        break;
+                    case Attributes.Symmetric:
+                        if (isGood && raw is bool sym)
+                        {
+                            rtn.Symmetric = sym;
+                        }
+                        break;
+                    case Attributes.InverseName:
+                        if (isGood && raw is LocalizedText inv)
+                        {
+                            rtn.InverseName = inv;
+                        }
+                        break;
+                }
+                break;
+            case DataTypeNode dtn:
+                switch (attributeId)
+                {
+                    case Attributes.IsAbstract:
+                        if (isGood && raw is bool absDt)
+                        {
+                            dtn.IsAbstract = absDt;
+                        }
+                        break;
+                    case Attributes.DataTypeDefinition:
+                        if (isGood && raw is ExtensionObject def)
+                        {
+                            dtn.DataTypeDefinition = def;
+                        }
+                        break;
+                }
+                break;
+            case MethodNode mn:
+                switch (attributeId)
+                {
+                    case Attributes.Executable:
+                        mn.Executable = isGood && raw is bool ex && ex;
+                        break;
+                    case Attributes.UserExecutable:
+                        mn.UserExecutable = isGood && raw is bool uex && uex;
+                        break;
+                }
+                break;
+            case ViewNode vw:
+                switch (attributeId)
+                {
+                    case Attributes.ContainsNoLoops:
+                        vw.ContainsNoLoops = isGood && raw is bool nl && nl;
+                        break;
+                    case Attributes.EventNotifier:
+                        vw.EventNotifier = isGood && raw is byte vnb ? vnb : (byte)0;
+                        break;
+                }
+                break;
+        }
+    }
+
+    private static void ApplyVariableAttribute(
+        VariableNode vn, uint attributeId, DataValue dv, bool isGood, object? raw)
+    {
+        switch (attributeId)
+        {
+            case Attributes.Value:
+                if (isGood)
+                {
+                    vn.Value = dv.WrappedValue;
+                }
+                break;
+            case Attributes.DataType:
+                if (isGood && raw is NodeId dt)
+                {
+                    vn.DataType = dt;
+                }
+                break;
+            case Attributes.ValueRank:
+                vn.ValueRank = isGood && raw is int vr ? vr : ValueRanks.Scalar;
+                break;
+            case Attributes.ArrayDimensions:
+                vn.ArrayDimensions = isGood && raw is uint[] dims
+                    ? new UInt32Collection(dims)
+                    : new UInt32Collection();
+                break;
+            case Attributes.AccessLevel:
+                vn.AccessLevel = isGood && raw is byte al ? al : (byte)0;
+                break;
+            case Attributes.UserAccessLevel:
+                vn.UserAccessLevel = isGood && raw is byte ual ? ual : (byte)0;
+                break;
+            case Attributes.MinimumSamplingInterval:
+                vn.MinimumSamplingInterval = isGood && raw is double ms ? ms : 0d;
+                break;
+            case Attributes.Historizing:
+                vn.Historizing = isGood && raw is bool hi && hi;
+                break;
+            case Attributes.AccessLevelEx:
+                if (isGood && raw is uint ax)
+                {
+                    vn.AccessLevelEx = ax;
+                }
+                break;
+        }
+    }
+
+    private static void ApplyVariableTypeAttribute(
+        VariableTypeNode vtn, uint attributeId, DataValue dv, bool isGood, object? raw)
+    {
+        switch (attributeId)
+        {
+            case Attributes.Value:
+                if (isGood)
+                {
+                    vtn.Value = dv.WrappedValue;
+                }
+                break;
+            case Attributes.DataType:
+                if (isGood && raw is NodeId dt)
+                {
+                    vtn.DataType = dt;
+                }
+                break;
+            case Attributes.ValueRank:
+                vtn.ValueRank = isGood && raw is int vr ? vr : ValueRanks.Scalar;
+                break;
+            case Attributes.ArrayDimensions:
+                vtn.ArrayDimensions = isGood && raw is uint[] dims
+                    ? new UInt32Collection(dims)
+                    : new UInt32Collection();
+                break;
+            case Attributes.IsAbstract:
+                if (isGood && raw is bool abs)
+                {
+                    vtn.IsAbstract = abs;
+                }
+                break;
+        }
+    }
+
+    /// <summary>
+    /// Writes a JSON sidecar next to <paramref name="nodeSet2FilePath"/> that
+    /// records every standard attribute (and its <see cref="StatusCode"/>) for
+    /// each node in the export. Intended for diagnostic inspection — e.g.,
+    /// detecting variables that have an unreadable or empty <c>Value</c>.
+    /// </summary>
+    /// <remarks>
+    /// The sidecar issues a raw <c>Read</c> service call for the (node,
+    /// attribute) pairs relevant to each node's <see cref="NodeClass"/> so the
+    /// recorded status codes reflect what the server actually returned. The
+    /// in-memory hydration done by
+    /// <see cref="HydrateNodeAttributesAsync"/> does not preserve per-attribute
+    /// status codes, so a dedicated read is required here.
+    /// </remarks>
+    private async Task WriteAttributesJsonSidecarAsync(
+        IList<INode> nodes,
+        ushort namespaceIndex,
+        string namespaceUri,
+        string nodeSet2FilePath,
+        CancellationToken cancellationToken)
+    {
+        if (nodes.Count == 0)
+        {
+            return;
+        }
+
+        var sidecarPath = Path.ChangeExtension(nodeSet2FilePath, null) + "_attributes.json";
+        _logger.LogInformation("Writing attribute diagnostic file: {Path}", sidecarPath);
+
+        // Filter to the nodes that actually belong to this namespace.
+        var relevantNodes = nodes
+            .Where(n => n.NodeId.NamespaceIndex == namespaceIndex)
+            .ToList();
+
+        if (relevantNodes.Count == 0)
+        {
+            _logger.LogDebug("No nodes in namespace {Index} to write to sidecar.", namespaceIndex);
+            return;
+        }
+
+        var dump = await _client.ExecuteWithRetryAsync(async (session, ct) =>
+        {
+            uint maxNodesPerRead = session.OperationLimits?.MaxNodesPerRead ?? 0;
+            int chunkSize = maxNodesPerRead > 0 ? (int)maxNodesPerRead : (int)DefaultMaxNodesPerRead;
+
+            // Build (node, attribute id) requests, tagged with which node /
+            // attribute they map back to.
+            var requestsByNode = new Dictionary<int, List<(uint AttributeId, string Name)>>();
+            var flat = new List<(int NodeIndex, uint AttributeId, string Name, ReadValueId Rvid)>();
+
+            for (int ni = 0; ni < relevantNodes.Count; ni++)
+            {
+                var node = relevantNodes[ni];
+                var nodeId = ExpandedNodeId.ToNodeId(node.NodeId, session.NamespaceUris);
+                if (nodeId == null)
+                {
+                    continue;
+                }
+
+                foreach (var (attrId, attrName) in AttributesForNodeClass(node.NodeClass))
+                {
+                    flat.Add((ni, attrId, attrName, new ReadValueId
+                    {
+                        NodeId = nodeId,
+                        AttributeId = attrId,
+                    }));
+
+                    if (!requestsByNode.TryGetValue(ni, out var list))
+                    {
+                        list = new List<(uint, string)>();
+                        requestsByNode[ni] = list;
+                    }
+                    list.Add((attrId, attrName));
+                }
+            }
+
+            // Issue Read in chunks. Order is preserved so we can stitch back.
+            var allValues = new DataValue[flat.Count];
+
+            for (int offset = 0; offset < flat.Count; offset += chunkSize)
+            {
+                ct.ThrowIfCancellationRequested();
+                int take = Math.Min(chunkSize, flat.Count - offset);
+
+                var nodesToRead = new ReadValueIdCollection(
+                    flat.Skip(offset).Take(take).Select(t => t.Rvid));
+
+                ReadResponse? response = null;
+                try
+                {
+                    response = await session.ReadAsync(
+                        requestHeader: null,
+                        maxAge: 0,
+                        timestampsToReturn: TimestampsToReturn.Neither,
+                        nodesToRead: nodesToRead,
+                        ct: ct).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex,
+                        "Sidecar Read chunk of {Count} (node,attribute) pairs failed; those attributes will be recorded as 'BadCommunicationError'.",
+                        take);
+                }
+
+                for (int i = 0; i < take; i++)
+                {
+                    if (response != null && i < response.Results.Count)
+                    {
+                        allValues[offset + i] = response.Results[i];
+                    }
+                    else
+                    {
+                        allValues[offset + i] = new DataValue(StatusCodes.BadCommunicationError);
+                    }
+                }
+            }
+
+            // Build the per-node attribute dictionaries.
+            var nodeDumps = new List<NodeAttributeDump>(relevantNodes.Count);
+            for (int ni = 0; ni < relevantNodes.Count; ni++)
+            {
+                var node = relevantNodes[ni];
+                var attrs = new Dictionary<string, AttributeDump>(StringComparer.Ordinal);
+                nodeDumps.Add(new NodeAttributeDump
+                {
+                    NodeId = node.NodeId.ToString() ?? string.Empty,
+                    BrowseName = node.BrowseName?.ToString() ?? string.Empty,
+                    DisplayName = node.DisplayName?.Text ?? string.Empty,
+                    NodeClass = node.NodeClass.ToString(),
+                    Attributes = attrs,
+                });
+            }
+
+            for (int i = 0; i < flat.Count; i++)
+            {
+                var (nodeIndex, _, name, _) = flat[i];
+                var dv = allValues[i] ?? new DataValue(StatusCodes.BadNoData);
+                nodeDumps[nodeIndex].Attributes[name] = AttributeDump.FromDataValue(dv);
+            }
+
+            return new NamespaceAttributeDump
+            {
+                NamespaceUri = namespaceUri,
+                NamespaceIndex = namespaceIndex,
+                ExportedAt = DateTime.UtcNow,
+                Nodes = nodeDumps,
+            };
+        }, "WriteAttributesJsonSidecar", cancellationToken).ConfigureAwait(false);
+
+        var jsonOptions = new JsonSerializerOptions
+        {
+            WriteIndented = true,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+        };
+
+        await using var stream = new FileStream(
+            sidecarPath, FileMode.Create, FileAccess.Write, FileShare.None);
+        await JsonSerializer.SerializeAsync(stream, dump, jsonOptions, cancellationToken)
+            .ConfigureAwait(false);
+
+        _logger.LogInformation("Attribute diagnostic written for {Count} nodes -> {Path}",
+            dump.Nodes.Count, sidecarPath);
+    }
+
+    /// <summary>
+    /// Returns the OPC UA attribute ids (and human-readable names) that are
+    /// relevant to a given <see cref="NodeClass"/>. Mirrors the set written
+    /// by <c>CoreClientUtils.ExportNodesToNodeSet2</c>, plus <c>Value</c> for
+    /// Variable / VariableType nodes.
+    /// </summary>
+    private static IEnumerable<(uint AttributeId, string Name)> AttributesForNodeClass(NodeClass nodeClass)
+    {
+        // Common attributes for every node class.
+        yield return (Attributes.NodeClass, "NodeClass");
+        yield return (Attributes.BrowseName, "BrowseName");
+        yield return (Attributes.DisplayName, "DisplayName");
+        yield return (Attributes.Description, "Description");
+        yield return (Attributes.WriteMask, "WriteMask");
+        yield return (Attributes.UserWriteMask, "UserWriteMask");
+
+        switch (nodeClass)
+        {
+            case NodeClass.Variable:
+                yield return (Attributes.Value, "Value");
+                yield return (Attributes.DataType, "DataType");
+                yield return (Attributes.ValueRank, "ValueRank");
+                yield return (Attributes.ArrayDimensions, "ArrayDimensions");
+                yield return (Attributes.AccessLevel, "AccessLevel");
+                yield return (Attributes.UserAccessLevel, "UserAccessLevel");
+                yield return (Attributes.MinimumSamplingInterval, "MinimumSamplingInterval");
+                yield return (Attributes.Historizing, "Historizing");
+                yield return (Attributes.AccessLevelEx, "AccessLevelEx");
+                break;
+
+            case NodeClass.VariableType:
+                yield return (Attributes.Value, "Value");
+                yield return (Attributes.DataType, "DataType");
+                yield return (Attributes.ValueRank, "ValueRank");
+                yield return (Attributes.ArrayDimensions, "ArrayDimensions");
+                yield return (Attributes.IsAbstract, "IsAbstract");
+                break;
+
+            case NodeClass.Object:
+                yield return (Attributes.EventNotifier, "EventNotifier");
+                break;
+
+            case NodeClass.ObjectType:
+                yield return (Attributes.IsAbstract, "IsAbstract");
+                break;
+
+            case NodeClass.ReferenceType:
+                yield return (Attributes.IsAbstract, "IsAbstract");
+                yield return (Attributes.Symmetric, "Symmetric");
+                yield return (Attributes.InverseName, "InverseName");
+                break;
+
+            case NodeClass.DataType:
+                yield return (Attributes.IsAbstract, "IsAbstract");
+                yield return (Attributes.DataTypeDefinition, "DataTypeDefinition");
+                break;
+
+            case NodeClass.Method:
+                yield return (Attributes.Executable, "Executable");
+                yield return (Attributes.UserExecutable, "UserExecutable");
+                break;
+
+            case NodeClass.View:
+                yield return (Attributes.ContainsNoLoops, "ContainsNoLoops");
+                yield return (Attributes.EventNotifier, "EventNotifier");
+                break;
+        }
+    }
+
+    // ----- JSON DTOs for the attribute sidecar -----
+
+    private sealed class NamespaceAttributeDump
+    {
+        public string NamespaceUri { get; init; } = string.Empty;
+        public ushort NamespaceIndex { get; init; }
+        public DateTime ExportedAt { get; init; }
+        public List<NodeAttributeDump> Nodes { get; init; } = new();
+    }
+
+    private sealed class NodeAttributeDump
+    {
+        public string NodeId { get; init; } = string.Empty;
+        public string BrowseName { get; init; } = string.Empty;
+        public string DisplayName { get; init; } = string.Empty;
+        public string NodeClass { get; init; } = string.Empty;
+        public Dictionary<string, AttributeDump> Attributes { get; init; } = new();
+    }
+
+    /// <summary>
+    /// Serializable view of a single attribute Read result.
+    /// <c>Value</c> contains the JSON-serializable representation of the
+    /// attribute's value. Complex / non-JSON-friendly OPC UA types (NodeId,
+    /// ByteString, LocalizedText, DateTime, ExtensionObject, …) are
+    /// rendered as strings — consumers can look at the node's
+    /// <c>DataType</c> attribute to know the original type.
+    /// </summary>
+    public sealed class AttributeDump
+    {
+        public string Status { get; init; } = "Good";
+        public string? StatusCode { get; init; }
+        public object? Value { get; init; }
+
+        public static AttributeDump FromDataValue(DataValue dv)
+        {
+            var value = ConvertVariantToJsonFriendly(dv.WrappedValue);
+
+            string symbolic = global::Opc.Ua.StatusCodes.GetBrowseName(dv.StatusCode.Code);
+            if (string.IsNullOrEmpty(symbolic) || symbolic == dv.StatusCode.Code.ToString())
+            {
+                symbolic = $"0x{dv.StatusCode.Code:X8}";
+            }
+
+            return new AttributeDump
+            {
+                Status = symbolic,
+                StatusCode = $"0x{dv.StatusCode.Code:X8}",
+                Value = value,
+            };
+        }
+
+        private static object? ConvertVariantToJsonFriendly(Variant variant)
+        {
+            if (variant.Value == null || variant == Variant.Null)
+            {
+                return null;
+            }
+
+            var v = variant.Value;
+            switch (v)
+            {
+                case string:
+                case bool:
+                case sbyte or byte:
+                case short or ushort:
+                case int or uint:
+                case long or ulong:
+                case float or double:
+                case decimal:
+                    return v;
+                case DateTime dt:
+                    return dt.ToString("O", System.Globalization.CultureInfo.InvariantCulture);
+                case Guid g:
+                    return g.ToString();
+                case Uuid uuid:
+                    return uuid.ToString();
+                case byte[] bytes:
+                    return Convert.ToBase64String(bytes);
+                case XmlElement xe:
+                    return xe.OuterXml;
+                case LocalizedText lt:
+                    return lt.Text;
+                case QualifiedName qn:
+                    return qn.ToString();
+                case NodeId nid:
+                    return nid.ToString();
+                case ExpandedNodeId enid:
+                    return enid.ToString();
+                case StatusCode sc:
+                    return $"0x{sc.Code:X8}";
+            }
+
+            // Arrays of the above scalar types: convert element-wise.
+            if (v is Array arr)
+            {
+                var items = new List<object?>(arr.Length);
+                foreach (var item in arr)
+                {
+                    items.Add(ConvertVariantToJsonFriendly(new Variant(item)));
+                }
+                return items;
+            }
+
+            // Fallback: stringify ExtensionObject and any other complex value.
+            return v.ToString();
+        }
     }
 }

--- a/src/OpcUaNodesetExporter/OpcUa/NodeSetExporter.cs
+++ b/src/OpcUaNodesetExporter/OpcUa/NodeSetExporter.cs
@@ -26,6 +26,20 @@ public class NodeSetExporter
     private readonly bool _exportAttributes;
 
     /// <summary>
+    /// Shared JSON serialization options for the attribute sidecar. Exposed as
+    /// <c>internal</c> so unit tests can verify behaviour against the exact
+    /// same options used in production (NaN/±Infinity handling in particular).
+    /// </summary>
+    internal static readonly JsonSerializerOptions SidecarJsonOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+        NumberHandling = JsonNumberHandling.AllowNamedFloatingPointLiterals,
+    };
+
+    /// <summary>
     /// Creates a new NodeSetExporter instance.
     /// </summary>
     /// <param name="logger">Logger instance.</param>
@@ -1219,13 +1233,7 @@ public class NodeSetExporter
             };
         }, "WriteAttributesJsonSidecar", cancellationToken).ConfigureAwait(false);
 
-        var jsonOptions = new JsonSerializerOptions
-        {
-            WriteIndented = true,
-            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-            Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
-        };
+        var jsonOptions = SidecarJsonOptions;
 
         await using var stream = new FileStream(
             sidecarPath, FileMode.Create, FileAccess.Write, FileShare.None);
@@ -1372,9 +1380,12 @@ public class NodeSetExporter
                 case short or ushort:
                 case int or uint:
                 case long or ulong:
-                case float or double:
                 case decimal:
                     return v;
+                case float f:
+                    return float.IsFinite(f) ? f : FloatTokenFor(f);
+                case double d:
+                    return double.IsFinite(d) ? d : DoubleTokenFor(d);
                 case DateTime dt:
                     return dt.ToString("O", System.Globalization.CultureInfo.InvariantCulture);
                 case Guid g:
@@ -1410,6 +1421,26 @@ public class NodeSetExporter
 
             // Fallback: stringify ExtensionObject and any other complex value.
             return v.ToString();
+        }
+
+        private static string DoubleTokenFor(double d)
+        {
+            if (double.IsNaN(d))
+            {
+                return "NaN";
+            }
+
+            return double.IsPositiveInfinity(d) ? "Infinity" : "-Infinity";
+        }
+
+        private static string FloatTokenFor(float f)
+        {
+            if (float.IsNaN(f))
+            {
+                return "NaN";
+            }
+
+            return float.IsPositiveInfinity(f) ? "Infinity" : "-Infinity";
         }
     }
 }

--- a/src/OpcUaNodesetExporter/OpcUa/OpcUaClientOptions.cs
+++ b/src/OpcUaNodesetExporter/OpcUa/OpcUaClientOptions.cs
@@ -63,6 +63,15 @@ public class OpcUaClientOptions
     public bool Verbose { get; set; }
 
     /// <summary>
+    /// Optional path to a file that should additionally receive all log
+    /// output. When <see cref="Verbose"/> is <c>true</c>, the file captures
+    /// <c>Debug</c>-level entries; otherwise it mirrors the console's
+    /// <c>Information</c> level. Parent directories are created on demand and
+    /// the file is opened in append mode.
+    /// </summary>
+    public string? LogFile { get; set; }
+
+    /// <summary>
     /// When true, the exporter reads all standard attributes (including the
     /// <c>Value</c> attribute for Variable and VariableType nodes) and writes
     /// a JSON sidecar file per produced NodeSet2 XML that records every

--- a/src/OpcUaNodesetExporter/OpcUa/OpcUaClientOptions.cs
+++ b/src/OpcUaNodesetExporter/OpcUa/OpcUaClientOptions.cs
@@ -63,6 +63,15 @@ public class OpcUaClientOptions
     public bool Verbose { get; set; }
 
     /// <summary>
+    /// When true, the exporter reads all standard attributes (including the
+    /// <c>Value</c> attribute for Variable and VariableType nodes) and writes
+    /// a JSON sidecar file per produced NodeSet2 XML that records every
+    /// attribute and its <see cref="StatusCode"/>. This is primarily intended
+    /// for detecting nodes with empty values or unreadable attributes.
+    /// </summary>
+    public bool ExportAttributes { get; set; }
+
+    /// <summary>
     /// Number of reconnection attempts on disconnect.
     /// </summary>
     public int RetryCount { get; set; } = 3;

--- a/src/OpcUaNodesetExporter/OpcUaNodesetExporter.csproj
+++ b/src/OpcUaNodesetExporter/OpcUaNodesetExporter.csproj
@@ -40,4 +40,8 @@
     <None Include="..\..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="OpcUaNodesetExporter.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/tests/OpcUaNodesetExporter.AppHost/Program.cs
+++ b/tests/OpcUaNodesetExporter.AppHost/Program.cs
@@ -65,7 +65,8 @@ Directory.CreateDirectory(opcPlcAttrsFolder);
 builder.AddProject<OpcUaNodesetExporter>("umati-opcua-nodeset-exporter-with-attributes")
     .WithEnvironment("OPCUA_ENDPOINT", umatiServerEndpoint)
     .WithArgs("--output", umatiAttrsFolder)
-    .WithArgs("--export-attributes");
+    .WithArgs("--export-attributes")
+    .WithArgs("--verbose");
 
 builder.AddProject<OpcUaNodesetExporter>("opcplc-opcua-nodeset-exporter-with-attributes")
     .WithEnvironment("OPCUA_ENDPOINT", opcPlcEndpoint)

--- a/tests/OpcUaNodesetExporter.AppHost/Program.cs
+++ b/tests/OpcUaNodesetExporter.AppHost/Program.cs
@@ -53,4 +53,24 @@ builder.AddProject<OpcUaNodesetExporter>("opcplc-opcua-nodeset-exporter")
     .WithEnvironment("OPCUA_START_NODE", "nsu=http://microsoft.com/Opc/OpcPlc/Boiler;i=5017")
     .WithArgs("--output", exportFolder);
 
+// Additional exporter instances that exercise --export-attributes (full + subtree mode).
+// They write into dedicated subfolders so the JSON sidecars don't collide with the
+// "plain" exports above.
+var umatiAttrsFolder = Path.Combine(exportFolder, "umati-attrs");
+Directory.CreateDirectory(umatiAttrsFolder);
+
+var opcPlcAttrsFolder = Path.Combine(exportFolder, "opcplc-attrs");
+Directory.CreateDirectory(opcPlcAttrsFolder);
+
+builder.AddProject<OpcUaNodesetExporter>("umati-opcua-nodeset-exporter-with-attributes")
+    .WithEnvironment("OPCUA_ENDPOINT", umatiServerEndpoint)
+    .WithArgs("--output", umatiAttrsFolder)
+    .WithArgs("--export-attributes");
+
+builder.AddProject<OpcUaNodesetExporter>("opcplc-opcua-nodeset-exporter-with-attributes")
+    .WithEnvironment("OPCUA_ENDPOINT", opcPlcEndpoint)
+    .WithEnvironment("OPCUA_START_NODE", "nsu=http://microsoft.com/Opc/OpcPlc/Boiler;i=5017")
+    .WithArgs("--output", opcPlcAttrsFolder)
+    .WithArgs("--export-attributes");
+
 builder.Build().Run();

--- a/tests/OpcUaNodesetExporter.Tests/ApplyAttributeToNodeTests.cs
+++ b/tests/OpcUaNodesetExporter.Tests/ApplyAttributeToNodeTests.cs
@@ -1,0 +1,161 @@
+using Opc.Ua;
+using OpcUaNodesetExporter.OpcUa;
+
+namespace OpcUaNodesetExporter.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="NodeSetExporter.ApplyAttributeToNode"/> — the
+/// per-attribute mutator that <see cref="NodeSetExporter"/> uses to hydrate
+/// cached <see cref="Node"/> instances after a raw Read call. These tests
+/// are the regression net for the &quot;<c>ValueRank=-2</c> still in XML&quot;
+/// problem: if hydration does not actually mutate the node, the SDK
+/// exporter falls back to <see cref="ValueRanks.Any"/> (-2) when serialising.
+/// </summary>
+public class ApplyAttributeToNodeTests
+{
+    [Fact]
+    public void Variable_ValueRank_Good_AppliesServerValue()
+    {
+        var node = new VariableNode { ValueRank = ValueRanks.Any };
+
+        NodeSetExporter.ApplyAttributeToNode(
+            node,
+            Attributes.ValueRank,
+            new DataValue(new Variant(ValueRanks.OneDimension)));
+
+        Assert.Equal(ValueRanks.OneDimension, node.ValueRank);
+    }
+
+    [Fact]
+    public void Variable_ValueRank_BadStatus_AppliesScalarSchemaDefault()
+    {
+        var node = new VariableNode { ValueRank = ValueRanks.Any };
+
+        NodeSetExporter.ApplyAttributeToNode(
+            node,
+            Attributes.ValueRank,
+            new DataValue(StatusCodes.BadAttributeIdInvalid));
+
+        // -1 (Scalar) is the NodeSet2 XML schema default — the SDK exporter
+        // omits the attribute entirely when it equals -1.
+        Assert.Equal(ValueRanks.Scalar, node.ValueRank);
+    }
+
+    [Fact]
+    public void Variable_MinimumSamplingInterval_BadStatus_AppliesZeroDefault()
+    {
+        var node = new VariableNode { MinimumSamplingInterval = -1 };
+
+        NodeSetExporter.ApplyAttributeToNode(
+            node,
+            Attributes.MinimumSamplingInterval,
+            new DataValue(StatusCodes.BadNotReadable));
+
+        Assert.Equal(0d, node.MinimumSamplingInterval);
+    }
+
+    [Fact]
+    public void Variable_MinimumSamplingInterval_Good_AppliesServerValue()
+    {
+        var node = new VariableNode { MinimumSamplingInterval = -1 };
+
+        NodeSetExporter.ApplyAttributeToNode(
+            node,
+            Attributes.MinimumSamplingInterval,
+            new DataValue(new Variant(250.0)));
+
+        Assert.Equal(250.0, node.MinimumSamplingInterval);
+    }
+
+    [Fact]
+    public void Variable_Value_Good_AppliesWrappedVariant()
+    {
+        var node = new VariableNode();
+
+        NodeSetExporter.ApplyAttributeToNode(
+            node,
+            Attributes.Value,
+            new DataValue(new Variant(42)));
+
+        Assert.Equal(42, node.Value.Value);
+    }
+
+    [Fact]
+    public void Variable_AccessLevel_BadStatus_AppliesZero()
+    {
+        var node = new VariableNode { AccessLevel = 99 };
+
+        NodeSetExporter.ApplyAttributeToNode(
+            node,
+            Attributes.AccessLevel,
+            new DataValue(StatusCodes.BadAttributeIdInvalid));
+
+        Assert.Equal((byte)0, node.AccessLevel);
+    }
+
+    [Fact]
+    public void Variable_Historizing_BadStatus_AppliesFalse()
+    {
+        var node = new VariableNode { Historizing = true };
+
+        NodeSetExporter.ApplyAttributeToNode(
+            node,
+            Attributes.Historizing,
+            new DataValue(StatusCodes.BadAttributeIdInvalid));
+
+        Assert.False(node.Historizing);
+    }
+
+    [Fact]
+    public void VariableType_ValueRank_BadStatus_AppliesScalarSchemaDefault()
+    {
+        var node = new VariableTypeNode { ValueRank = ValueRanks.Any };
+
+        NodeSetExporter.ApplyAttributeToNode(
+            node,
+            Attributes.ValueRank,
+            new DataValue(StatusCodes.BadAttributeIdInvalid));
+
+        Assert.Equal(ValueRanks.Scalar, node.ValueRank);
+    }
+
+    [Fact]
+    public void VariableType_Value_Good_AppliesWrappedVariant()
+    {
+        var node = new VariableTypeNode();
+
+        NodeSetExporter.ApplyAttributeToNode(
+            node,
+            Attributes.Value,
+            new DataValue(new Variant("hello")));
+
+        Assert.Equal("hello", node.Value.Value);
+    }
+
+    [Fact]
+    public void Description_Good_AppliesLocalizedText()
+    {
+        var node = new VariableNode();
+        var description = new LocalizedText("en", "test description");
+
+        NodeSetExporter.ApplyAttributeToNode(
+            node,
+            Attributes.Description,
+            new DataValue(new Variant(description)));
+
+        Assert.Equal("test description", node.Description.Text);
+    }
+
+    [Fact]
+    public void Object_EventNotifier_BadStatus_AppliesZero()
+    {
+        var node = new ObjectNode { EventNotifier = 5 };
+
+        NodeSetExporter.ApplyAttributeToNode(
+            node,
+            Attributes.EventNotifier,
+            new DataValue(StatusCodes.BadAttributeIdInvalid));
+
+        Assert.Equal((byte)0, node.EventNotifier);
+    }
+}

--- a/tests/OpcUaNodesetExporter.Tests/AttributeDumpTests.cs
+++ b/tests/OpcUaNodesetExporter.Tests/AttributeDumpTests.cs
@@ -105,4 +105,84 @@ public class AttributeDumpTests
         Assert.NotNull(dump.Value);
         Assert.IsType<string>(dump.Value);
     }
+
+    [Theory]
+    [InlineData(double.NaN, "NaN")]
+    [InlineData(double.PositiveInfinity, "Infinity")]
+    [InlineData(double.NegativeInfinity, "-Infinity")]
+    public void FromDataValue_NonFiniteDouble_IsConvertedToToken(double value, string expectedToken)
+    {
+        var dv = new DataValue(new Variant(value));
+
+        var dump = NodeSetExporter.AttributeDump.FromDataValue(dv);
+
+        Assert.Equal(expectedToken, dump.Value);
+    }
+
+    [Theory]
+    [InlineData(float.NaN, "NaN")]
+    [InlineData(float.PositiveInfinity, "Infinity")]
+    [InlineData(float.NegativeInfinity, "-Infinity")]
+    public void FromDataValue_NonFiniteFloat_IsConvertedToToken(float value, string expectedToken)
+    {
+        var dv = new DataValue(new Variant(value));
+
+        var dump = NodeSetExporter.AttributeDump.FromDataValue(dv);
+
+        Assert.Equal(expectedToken, dump.Value);
+    }
+
+    [Fact]
+    public void FromDataValue_FiniteDouble_RoundTripsAsDouble()
+    {
+        var dv = new DataValue(new Variant(3.14159));
+
+        var dump = NodeSetExporter.AttributeDump.FromDataValue(dv);
+
+        Assert.Equal(3.14159, Assert.IsType<double>(dump.Value));
+    }
+
+    [Fact]
+    public void FromDataValue_DoubleArrayWithNaN_ConvertsTokenElementWise()
+    {
+        var arr = new[] { 1.0, double.NaN, double.PositiveInfinity, double.NegativeInfinity, 2.5 };
+        var dv = new DataValue(new Variant(arr));
+
+        var dump = NodeSetExporter.AttributeDump.FromDataValue(dv);
+
+        var list = Assert.IsAssignableFrom<System.Collections.Generic.List<object?>>(dump.Value);
+        Assert.Equal(5, list.Count);
+        Assert.Equal(1.0, list[0]);
+        Assert.Equal("NaN", list[1]);
+        Assert.Equal("Infinity", list[2]);
+        Assert.Equal("-Infinity", list[3]);
+        Assert.Equal(2.5, list[4]);
+    }
+
+    [Fact]
+    public async Task Serialize_DumpWithNonFiniteValues_DoesNotThrow()
+    {
+        // Direct regression test for the CI failure: serialise an
+        // AttributeDump containing NaN / +-Infinity using the same options
+        // the production sidecar writer uses and assert no exception.
+        var dumpNan = NodeSetExporter.AttributeDump.FromDataValue(new DataValue(new Variant(double.NaN)));
+        var dumpInf = NodeSetExporter.AttributeDump.FromDataValue(new DataValue(new Variant(double.PositiveInfinity)));
+        var dumpNegInf = NodeSetExporter.AttributeDump.FromDataValue(new DataValue(new Variant(double.NegativeInfinity)));
+        var dumpArr = NodeSetExporter.AttributeDump.FromDataValue(
+            new DataValue(new Variant(new[] { 1.0, double.NaN, double.PositiveInfinity })));
+
+        var payload = new
+        {
+            Items = new[] { dumpNan, dumpInf, dumpNegInf, dumpArr },
+        };
+
+        await using var stream = new MemoryStream();
+        await System.Text.Json.JsonSerializer.SerializeAsync(
+            stream, payload, NodeSetExporter.SidecarJsonOptions);
+
+        var json = System.Text.Encoding.UTF8.GetString(stream.ToArray());
+        Assert.Contains("\"NaN\"", json);
+        Assert.Contains("\"Infinity\"", json);
+        Assert.Contains("\"-Infinity\"", json);
+    }
 }

--- a/tests/OpcUaNodesetExporter.Tests/AttributeDumpTests.cs
+++ b/tests/OpcUaNodesetExporter.Tests/AttributeDumpTests.cs
@@ -1,0 +1,108 @@
+using Opc.Ua;
+using OpcUaNodesetExporter.OpcUa;
+
+namespace OpcUaNodesetExporter.Tests;
+
+public class AttributeDumpTests
+{
+    [Fact]
+    public void FromDataValue_Good_PreservesScalarValueAndStatus()
+    {
+        var dv = new DataValue(new Variant(42), StatusCodes.Good, DateTime.UtcNow);
+
+        var dump = NodeSetExporter.AttributeDump.FromDataValue(dv);
+
+        Assert.Equal(42, dump.Value);
+        Assert.Equal("0x00000000", dump.StatusCode);
+        Assert.Equal("Good", dump.Status);
+    }
+
+    [Fact]
+    public void FromDataValue_BadStatus_RecordsSymbolicName()
+    {
+        var dv = new DataValue(StatusCodes.BadAttributeIdInvalid);
+
+        var dump = NodeSetExporter.AttributeDump.FromDataValue(dv);
+
+        Assert.Null(dump.Value);
+        Assert.Contains("Bad", dump.Status);
+        Assert.StartsWith("0x", dump.StatusCode);
+    }
+
+    [Fact]
+    public void FromDataValue_StringValue_IsCopiedThroughAsIs()
+    {
+        var dv = new DataValue(new Variant("hello"));
+
+        var dump = NodeSetExporter.AttributeDump.FromDataValue(dv);
+
+        Assert.Equal("hello", dump.Value);
+    }
+
+    [Fact]
+    public void FromDataValue_LocalizedText_FallsBackToStringRepresentation()
+    {
+        var dv = new DataValue(new Variant(new LocalizedText("en", "Hello")));
+
+        var dump = NodeSetExporter.AttributeDump.FromDataValue(dv);
+
+        Assert.Equal("Hello", dump.Value);
+    }
+
+    [Fact]
+    public void FromDataValue_NodeId_FallsBackToString()
+    {
+        var dv = new DataValue(new Variant(new NodeId(42, 3)));
+
+        var dump = NodeSetExporter.AttributeDump.FromDataValue(dv);
+
+        Assert.IsType<string>(dump.Value);
+        Assert.Contains("ns=3", (string)dump.Value!);
+    }
+
+    [Fact]
+    public void FromDataValue_ByteArray_IsBase64Encoded()
+    {
+        var bytes = new byte[] { 0x01, 0x02, 0x03 };
+        var dv = new DataValue(new Variant(bytes));
+
+        var dump = NodeSetExporter.AttributeDump.FromDataValue(dv);
+
+        Assert.Equal(Convert.ToBase64String(bytes), dump.Value);
+    }
+
+    [Fact]
+    public void FromDataValue_Array_ConvertsElementWise()
+    {
+        var dv = new DataValue(new Variant(new int[] { 1, 2, 3 }));
+
+        var dump = NodeSetExporter.AttributeDump.FromDataValue(dv);
+
+        var items = Assert.IsType<List<object?>>(dump.Value);
+        Assert.Equal(new object?[] { 1, 2, 3 }, items);
+    }
+
+    [Fact]
+    public void FromDataValue_NullVariant_RecordsNullValue()
+    {
+        var dv = new DataValue(Variant.Null);
+
+        var dump = NodeSetExporter.AttributeDump.FromDataValue(dv);
+
+        Assert.Null(dump.Value);
+    }
+
+    [Fact]
+    public void FromDataValue_ExtensionObject_FallsBackToString()
+    {
+        // ExtensionObject without an explicit JSON representation should be
+        // serialised as a string so the diagnostic file stays JSON-valid.
+        var ext = new ExtensionObject(ObjectIds.Server, new byte[] { 0x10 });
+        var dv = new DataValue(new Variant(ext));
+
+        var dump = NodeSetExporter.AttributeDump.FromDataValue(dv);
+
+        Assert.NotNull(dump.Value);
+        Assert.IsType<string>(dump.Value);
+    }
+}

--- a/tests/OpcUaNodesetExporter.Tests/FileLoggerProviderTests.cs
+++ b/tests/OpcUaNodesetExporter.Tests/FileLoggerProviderTests.cs
@@ -1,0 +1,154 @@
+using Microsoft.Extensions.Logging;
+using OpcUaNodesetExporter.Logging;
+
+namespace OpcUaNodesetExporter.Tests;
+
+public class FileLoggerProviderTests
+{
+    [Fact]
+    public void Logs_AreWrittenToFile_WithLevelAndCategoryTokens()
+    {
+        var path = Path.Combine(Path.GetTempPath(),
+            "opcua-flp-" + Guid.NewGuid().ToString("N") + ".log");
+        try
+        {
+            using (var provider = new FileLoggerProvider(path, LogLevel.Debug, append: false))
+            {
+                var logger = provider.CreateLogger("UnitTest");
+                logger.LogDebug("debug-line");
+                logger.LogInformation("info-line {Num}", 42);
+                logger.LogWarning("warn-line");
+            }
+
+            Assert.True(File.Exists(path));
+            var contents = File.ReadAllText(path);
+            Assert.Contains("[DBG] UnitTest: debug-line", contents);
+            Assert.Contains("[INF] UnitTest: info-line 42", contents);
+            Assert.Contains("[WRN] UnitTest: warn-line", contents);
+        }
+        finally
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+    }
+
+    [Fact]
+    public void EntriesBelowMinLevel_AreFiltered()
+    {
+        var path = Path.Combine(Path.GetTempPath(),
+            "opcua-flp-" + Guid.NewGuid().ToString("N") + ".log");
+        try
+        {
+            using (var provider = new FileLoggerProvider(path, LogLevel.Warning, append: false))
+            {
+                var logger = provider.CreateLogger("UnitTest");
+                logger.LogInformation("should-not-appear");
+                logger.LogDebug("also-not-here");
+                logger.LogWarning("kept");
+                logger.LogError("also-kept");
+            }
+
+            var contents = File.ReadAllText(path);
+            Assert.DoesNotContain("should-not-appear", contents);
+            Assert.DoesNotContain("also-not-here", contents);
+            Assert.Contains("kept", contents);
+            Assert.Contains("also-kept", contents);
+        }
+        finally
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+    }
+
+    [Fact]
+    public void ParentDirectory_IsCreatedOnDemand()
+    {
+        var dir = Path.Combine(Path.GetTempPath(),
+            "opcua-flp-" + Guid.NewGuid().ToString("N"), "nested", "subdir");
+        var path = Path.Combine(dir, "log.txt");
+        try
+        {
+            using (var provider = new FileLoggerProvider(path, LogLevel.Trace, append: false))
+            {
+                provider.CreateLogger("Cat").LogInformation("hi");
+            }
+
+            Assert.True(File.Exists(path));
+            Assert.Contains("hi", File.ReadAllText(path));
+        }
+        finally
+        {
+            if (Directory.Exists(dir))
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public void Append_PreservesExistingContents()
+    {
+        var path = Path.Combine(Path.GetTempPath(),
+            "opcua-flp-" + Guid.NewGuid().ToString("N") + ".log");
+        try
+        {
+            File.WriteAllText(path, "previous-content\n");
+
+            using (var provider = new FileLoggerProvider(path, LogLevel.Trace, append: true))
+            {
+                provider.CreateLogger("Cat").LogInformation("new-entry");
+            }
+
+            var contents = File.ReadAllText(path);
+            Assert.Contains("previous-content", contents);
+            Assert.Contains("new-entry", contents);
+        }
+        finally
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+    }
+
+    [Fact]
+    public void Exceptions_AreSerialised_AfterMessage()
+    {
+        var path = Path.Combine(Path.GetTempPath(),
+            "opcua-flp-" + Guid.NewGuid().ToString("N") + ".log");
+        try
+        {
+            using (var provider = new FileLoggerProvider(path, LogLevel.Trace, append: false))
+            {
+                var logger = provider.CreateLogger("Cat");
+                logger.LogError(new InvalidOperationException("boom"), "operation failed");
+            }
+
+            var contents = File.ReadAllText(path);
+            Assert.Contains("operation failed", contents);
+            Assert.Contains("InvalidOperationException", contents);
+            Assert.Contains("boom", contents);
+        }
+        finally
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+    }
+
+    [Fact]
+    public void EmptyPath_Throws()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            new FileLoggerProvider("", LogLevel.Trace));
+    }
+}

--- a/tests/OpcUaNodesetExporter.Tests/IntegrationTests.cs
+++ b/tests/OpcUaNodesetExporter.Tests/IntegrationTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Aspire.Hosting;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Testing;
@@ -249,6 +250,310 @@ public class IntegrationTests : IAsyncLifetime
             // but should NOT include UAObjectType/UAVariableType nodes from namespace 0
             // (OPC UA base types like BaseObjectType are ns=0 and should not be exported as nodes)
             Assert.DoesNotContain("NodeId=\"i=", xmlContent); // No ns=0 node definitions
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                Directory.Delete(tempDir, true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task DefaultExport_VariablesHaveRealValueRankAndMinimumSamplingInterval()
+    {
+        // Regression test for the bug where every exported variable had
+        // ValueRank="-2" and MinimumSamplingInterval="-1" — those are the
+        // SDK's in-memory defaults that leak through when only Browse is used.
+        // After the HydrateNodeAttributes step, real server values must be
+        // emitted (or the attributes must be omitted entirely, taking the
+        // NodeSet2 XML defaults of ValueRank=-1 and MinimumSamplingInterval=0).
+        Assert.NotNull(_opcUaEndpoint);
+
+        using var loggerFactory = LoggerFactory.Create(builder =>
+        {
+            builder.AddConsole();
+            builder.SetMinimumLevel(LogLevel.Information);
+        });
+
+        var tempDir = Path.Combine(Path.GetTempPath(), "opcua-hydrate-test-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            var options = new OpcUaClientOptions
+            {
+                Endpoint = _opcUaEndpoint,
+                OutputDirectory = tempDir,
+                RetryCount = 3,
+                RetryDelaySeconds = 5
+            };
+
+            await using var client = await OpcUaClientBuilder
+                .Create(loggerFactory)
+                .FromOptions(options)
+                .TrustAllServerCertificates()
+                .ConnectAsync();
+
+            var exporter = new NodeSetExporter(
+                loggerFactory.CreateLogger<NodeSetExporter>(),
+                loggerFactory,
+                client,
+                verbose: false);
+
+            var exportedFiles = await exporter.ExportAllNamespacesAsync(tempDir);
+
+            Assert.NotEmpty(exportedFiles);
+
+            // Inspect every NodeSet2 XML file: the placeholder defaults must
+            // not be present on any UAVariable element. The SDK only writes
+            // attributes that differ from the schema default, so seeing
+            // ValueRank="-2" or MinimumSamplingInterval="-1" indicates the bug
+            // has regressed (those are SDK in-memory defaults, not legal server
+            // values).
+            foreach (var xmlPath in exportedFiles.Values)
+            {
+                var xml = await File.ReadAllTextAsync(xmlPath);
+                Assert.DoesNotContain("ValueRank=\"-2\"", xml);
+                Assert.DoesNotContain("MinimumSamplingInterval=\"-1\"", xml);
+            }
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                Directory.Delete(tempDir, true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task DefaultExport_PreservesReferences()
+    {
+        // Regression test: the attribute-hydration pass must not strip the
+        // node references collected via Browse. Earlier versions replaced the
+        // cached INode with a freshly-read Node that had no references, which
+        // caused CoreClientUtils.ExportNodesToNodeSet2 to emit a NodeSet2 XML
+        // with no <References> blocks at all.
+        Assert.NotNull(_opcUaEndpoint);
+
+        using var loggerFactory = LoggerFactory.Create(builder =>
+        {
+            builder.AddConsole();
+            builder.SetMinimumLevel(LogLevel.Information);
+        });
+
+        var tempDir = Path.Combine(Path.GetTempPath(), "opcua-refs-test-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            var options = new OpcUaClientOptions
+            {
+                Endpoint = _opcUaEndpoint,
+                OutputDirectory = tempDir,
+                RetryCount = 3,
+                RetryDelaySeconds = 5
+            };
+
+            await using var client = await OpcUaClientBuilder
+                .Create(loggerFactory)
+                .FromOptions(options)
+                .TrustAllServerCertificates()
+                .ConnectAsync();
+
+            var exporter = new NodeSetExporter(
+                loggerFactory.CreateLogger<NodeSetExporter>(),
+                loggerFactory,
+                client,
+                verbose: false);
+
+            var exportedFiles = await exporter.ExportAllNamespacesAsync(tempDir);
+
+            Assert.NotEmpty(exportedFiles);
+
+            bool anyReferences = false;
+            foreach (var xmlPath in exportedFiles.Values)
+            {
+                var xml = await File.ReadAllTextAsync(xmlPath);
+                if (xml.Contains("<References>") || xml.Contains("<Reference "))
+                {
+                    anyReferences = true;
+                    break;
+                }
+            }
+
+            Assert.True(anyReferences,
+                "Expected at least one exported NodeSet2 file to contain <References>/<Reference> blocks.");
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                Directory.Delete(tempDir, true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task ExportAttributes_ProducesJsonSidecarPerNamespace()
+    {
+        Assert.NotNull(_opcUaEndpoint);
+
+        using var loggerFactory = LoggerFactory.Create(builder =>
+        {
+            builder.AddConsole();
+            builder.SetMinimumLevel(LogLevel.Information);
+        });
+
+        var tempDir = Path.Combine(Path.GetTempPath(), "opcua-attrs-test-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            var options = new OpcUaClientOptions
+            {
+                Endpoint = _opcUaEndpoint,
+                OutputDirectory = tempDir,
+                RetryCount = 3,
+                RetryDelaySeconds = 5,
+                ExportAttributes = true
+            };
+
+            await using var client = await OpcUaClientBuilder
+                .Create(loggerFactory)
+                .FromOptions(options)
+                .TrustAllServerCertificates()
+                .ConnectAsync();
+
+            var exporter = new NodeSetExporter(
+                loggerFactory.CreateLogger<NodeSetExporter>(),
+                loggerFactory,
+                client,
+                verbose: false,
+                exportAttributes: true);
+
+            var exportedFiles = await exporter.ExportAllNamespacesAsync(tempDir);
+
+            Assert.NotEmpty(exportedFiles);
+
+            foreach (var xmlPath in exportedFiles.Values)
+            {
+                var sidecarPath = Path.ChangeExtension(xmlPath, null) + "_attributes.json";
+                Assert.True(File.Exists(sidecarPath),
+                    $"Expected JSON sidecar at {sidecarPath}");
+
+                using var stream = File.OpenRead(sidecarPath);
+                using var document = await JsonDocument.ParseAsync(stream);
+                var root = document.RootElement;
+
+                Assert.True(root.TryGetProperty("namespaceUri", out _));
+                Assert.True(root.TryGetProperty("namespaceIndex", out _));
+                Assert.True(root.TryGetProperty("exportedAt", out _));
+                Assert.True(root.TryGetProperty("nodes", out var nodes));
+                Assert.True(nodes.GetArrayLength() > 0);
+
+                // At least one Variable node should have a "Value" attribute key.
+                bool sawValueAttribute = false;
+                foreach (var node in nodes.EnumerateArray())
+                {
+                    if (node.GetProperty("nodeClass").GetString() == "Variable" &&
+                        node.GetProperty("attributes").TryGetProperty("Value", out var valueAttr) &&
+                        valueAttr.TryGetProperty("status", out _))
+                    {
+                        sawValueAttribute = true;
+                        break;
+                    }
+                }
+                Assert.True(sawValueAttribute,
+                    "Expected at least one Variable node with a 'Value' attribute in the sidecar.");
+            }
+
+            // Regression check: when --export-attributes is set, the NodeSet2
+            // XML itself must also contain <Value> elements (NodeSetExportOptions.ExportValues=true).
+            // Earlier versions wrote them only to the JSON sidecar.
+            bool sawValueElementInXml = false;
+            foreach (var xmlPath in exportedFiles.Values)
+            {
+                var xml = await File.ReadAllTextAsync(xmlPath);
+                if (xml.Contains("<Value>") || xml.Contains("<Value "))
+                {
+                    sawValueElementInXml = true;
+                    break;
+                }
+            }
+            Assert.True(sawValueElementInXml,
+                "Expected at least one exported NodeSet2 XML to contain a <Value> element when --export-attributes is set.");
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                Directory.Delete(tempDir, true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task SubtreeExport_WithExportAttributes_ProducesJsonSidecar()
+    {
+        Assert.NotNull(_opcUaEndpoint);
+
+        using var loggerFactory = LoggerFactory.Create(builder =>
+        {
+            builder.AddConsole();
+            builder.SetMinimumLevel(LogLevel.Information);
+        });
+
+        var tempDir = Path.Combine(Path.GetTempPath(), "opcua-attrs-subtree-test-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            var options = new OpcUaClientOptions
+            {
+                Endpoint = _opcUaEndpoint,
+                RetryCount = 3,
+                RetryDelaySeconds = 5,
+                ExportAttributes = true
+            };
+
+            await using var client = await OpcUaClientBuilder
+                .Create(loggerFactory)
+                .FromOptions(options)
+                .TrustAllServerCertificates()
+                .ConnectAsync();
+
+            var exporter = new NodeSetExporter(
+                loggerFactory.CreateLogger<NodeSetExporter>(),
+                loggerFactory,
+                client,
+                verbose: false,
+                exportAttributes: true);
+
+            var startNodeId = Opc.Ua.ExpandedNodeId.Parse(
+                "ns=4;i=5", client.Session.NamespaceUris);
+
+            var exportedFile = await exporter.ExportSubtreeAsync(startNodeId, tempDir);
+
+            Assert.True(File.Exists(exportedFile));
+            var sidecarPath = Path.ChangeExtension(exportedFile, null) + "_attributes.json";
+            Assert.True(File.Exists(sidecarPath),
+                $"Expected sidecar JSON at {sidecarPath}");
+
+            using var stream = File.OpenRead(sidecarPath);
+            using var document = await JsonDocument.ParseAsync(stream);
+            var root = document.RootElement;
+
+            Assert.Equal(4, root.GetProperty("namespaceIndex").GetInt32());
+            Assert.True(root.GetProperty("nodes").GetArrayLength() > 0);
+
+            // Regression check: <Value> must also appear in the NodeSet2 XML
+            // itself when --export-attributes is set, not only in the JSON sidecar.
+            var xml = await File.ReadAllTextAsync(exportedFile);
+            Assert.True(xml.Contains("<Value>") || xml.Contains("<Value "),
+                "Expected <Value> element in NodeSet2 XML subtree export with --export-attributes.");
         }
         finally
         {


### PR DESCRIPTION
Implements --export-attributes to export all standard node attributes and their status codes to a JSON sidecar per NodeSet2 file. Ensures NodeSet2 XML reflects real server values for attributes like ValueRank and MinimumSamplingInterval. Updates README with usage and examples. Adds unit and integration tests for attribute hydration, JSON output, and regression coverage. Exposes internals for testing and updates Aspire scripts to cover the new feature.